### PR TITLE
Allow files named *.mp4 to be handled like *.m4a.

### DIFF
--- a/gmusicbrowser.pl
+++ b/gmusicbrowser.pl
@@ -150,7 +150,7 @@ BEGIN
 }
 
 our %Alias_ext;	#define alternate file extensions (ie: .ogg files treated as .oga files)
-INIT {%Alias_ext=(ogg=> 'oga', m4b=>'m4a');} #needs to be in a INIT block because used in a INIT block in gmusicbrowser_tags.pm
+INIT {%Alias_ext=(ogg=> 'oga', m4b=>'m4a', mp4=>'m4a');} #needs to be in a INIT block because used in a INIT block in gmusicbrowser_tags.pm
 
 our $debug;
 our %CmdLine;
@@ -4473,7 +4473,7 @@ sub ChoosePix
 					'gtk-cancel' => 'none');
 
 	for my $aref
-	(	[_"Pictures and music files",'image/*','*.mp3 *.flac *.m4a *.m4b *.ogg *.oga' ],
+	(	[_"Pictures and music files",'image/*','*.mp3 *.flac *.m4a *.m4b *.mp4 *.ogg *.oga' ],
 		[_"Pictures files",'image/*'],
 		[_"All files",undef,'*'],
 	)
@@ -4525,7 +4525,7 @@ sub ChoosePix
 		  $max=0;
 		  $nb=0 unless $lastfile && $lastfile eq $file;
 		  $lastfile=$file;
-		  if ($file=~m/\.(?:mp3|flac|m4a|m4b|oga|ogg)$/i)
+		  if ($file=~m/\.(?:mp3|flac|m4a|m4b|mp4|oga|ogg)$/i)
 		  {	my @pix= FileTag::PixFromMusicFile($file);
 			$max=@pix;
 		  }
@@ -5429,7 +5429,7 @@ sub MakeScanRegex	#FIXME
 		$ext{$_}=1 for grep $ext{$Alias_ext{$_}}, keys %Alias_ext;
 		$s=join '|',keys %ext;
 	}
-	else { $s='mp3|ogg|oga|flac|mpc|ape|wv|m4a|m4b'; } #FIXME find a better way
+	else { $s='mp3|ogg|oga|flac|mpc|ape|wv|m4a|m4b|mp4'; } #FIXME find a better way
 	$ScanRegex=qr/\.(?:$s)$/i;
 }
 
@@ -5576,7 +5576,7 @@ sub AutoSelPicture
 	{	my $file= AAPicture::GetPicture($field,$gid);
 		if (defined $file)
 		{	return unless $file; # file eq '0' => no picture
-			if ($file=~m/\.(?:mp3|flac|m4a|m4b|oga|ogg)(?::(\w+))?$/) { return if FileTag::PixFromMusicFile($file,$1,1); }
+			if ($file=~m/\.(?:mp3|flac|m4a|m4b|mp4|oga|ogg)(?::(\w+))?$/) { return if FileTag::PixFromMusicFile($file,$1,1); }
 			else { return if -e $file }
 		}
 	}
@@ -5588,7 +5588,7 @@ sub AutoSelPicture
 	my %pictures_files;
 	for my $m (qw/embedded guess/)
 	{	if ($m eq 'embedded')
-		{	my @files= grep m/\.(?:mp3|flac|m4a|m4b|ogg|oga)$/i, Songs::Map('fullfilename',$IDs);
+		{	my @files= grep m/\.(?:mp3|flac|m4a|m4b|mp4|ogg|oga)$/i, Songs::Map('fullfilename',$IDs);
 			if (@files)
 			{	$set= first { FileTag::PixFromMusicFile($_,$field,1) && $_ } @files;
 			}
@@ -8935,7 +8935,7 @@ sub load
 
 	my $loader=Gtk2::Gdk::PixbufLoader->new;
 	$loader->signal_connect(size_prepared => \&PixLoader_callback,$size) if $size;
-	if ($file=~m/\.(?:mp3|flac|m4a|m4b|ogg|oga)$/i)
+	if ($file=~m/\.(?:mp3|flac|m4a|m4b|mp4|ogg|oga)$/i)
 	{	my $data=FileTag::PixFromMusicFile($file,$nb);
 		eval { $loader->write($data) } if defined $data;
 	}


### PR DESCRIPTION
This pull request follows message in forum [gmusicbrowser ignores .m4a files without tags and all .mp4](http://forum.gmusicbrowser.org/index.php?topic=761.msg3557#msg3557) 

This pull requests solves part of the issue.
## Method

I figured out in source code that hashtable `%Alias_ext` is intended to handle some extensions like another, for example files named like `*.m4b` are already meant there to be handled just like `*.m4a`.

So I applied the very same pattern for mp4 wherever m4b was mentioned.
## Observed result

With this change, gmusicbrowser appears to indeed handle files named `*.mp4` like `*.mp4a`.

Some of my files are now recognized and can be played. 
## Request

Can you review and accept this pull request ? Thanks.
## Next step

I'll handle the second issue ("can't read tag") mentioned in the forum separately.

Regards,
