### PR TITLE
Accept MPEG4 files without ilst box. 

### DIFF
--- a/m4aheader.pm
+++ b/m4aheader.pm
@@ -49,7 +49,7 @@ sub new
 	$self->ParseAtomTree;
 	$self->_close;
 
-	unless ($self->{info} && $self->{ilst})
+	unless ($self->{info})
 	{	warn "error, can't read file or not a valid m4a file\n";
 		return undef;
 	}


### PR DESCRIPTION
They work normally, only they will have empty fields for artist, name, etc.
MPEG4 files without ilst box are AFAIK valid mp4 files, so there's no reason to reject them as invalid. They play normally in gmusicbrowser with this patch.

This fixes the second and last issue reported on [gmusicbrowser ignores .m4a files without tags and all .mp4](http://forum.gmusicbrowser.org/index.php?topic=761.0)

Thanks.
