### PR TITLE
lyrics plugin: fix unhandled exception and add musixmatch.com to auto mode

### DIFF
--- a/plugins/lyrics.pm
+++ b/plugins/lyrics.pm
@@ -337,7 +337,7 @@ sub load_from_web
 	{	$site = $::Options{OPT.'LyricSite'};
 		delete $self->{trynext};
 		if ($site eq 'AUTO')
-		{	($site,@{$self->{trynext}})= qw/lyricssongs lyricwiki/;	#FIXME make it configurable
+		{	($site,@{$self->{trynext}})= qw/lyricssongs lyricwiki musixmatch/; #FIXME make it configurable
 		}
 	}
 	return unless $site;
@@ -428,10 +428,10 @@ sub loaded #_very_ crude html to gtktextview renderer
 	delete $self->{waiting};
 	my $type=$data_prop{type};
 	my $buffer=$self->{buffer};
-	unless ($data) { $data=_("Loading failed.").qq( <a href="$self->{url}">)._("retry").'</a>'; $type="text/html"; }
+       my $encoding;
+	unless ($data) { $data=_("Loading failed.").qq( <a href="$self->{url}">)._("retry").'</a>'; $type="text/html"; $encoding=0; }
 	$self->{url}=$data_prop{url} if $data_prop{url}; #for redirections
 	$buffer->delete($buffer->get_bounds);
-	my $encoding;
 	if ($type && $type=~m#^text/.*; ?charset=([\w-]+)#) {$encoding=$1}
 	if ($type && $type!~m#^text/html#)
 	{	if	($type=~m#^text/#)	{$buffer->set_text($data);}
@@ -443,7 +443,7 @@ sub loaded #_very_ crude html to gtktextview renderer
 	}
 	$encoding=$1 if $data=~m#<meta *http-equiv="Content-Type" *content="text/html; charset=([\w-]+)"#;
 	$encoding='cp1252' if $encoding && $encoding eq 'iso-8859-1'; #microsoft use the superset cp1252 of iso-8859-1 but says it's iso-8859-1
-	$encoding||='cp1252'; #default encoding
+	$encoding//='cp1252'; #default encoding
 	$data=Encode::decode($encoding,$data) if $encoding;
 
 	my $oklyrics;


### PR DESCRIPTION
Hi, Quentin! After I tried to add musixmatch to auto-mode I noticed one error.
Here is the log.
I started one song that is not in the first two sources (lyricssongs lyricwiki), and press "reload" button:
```
lyrics : loading http://letras.terra.com.br/winamp.php?musica=%D0%B4%D0%B0%D0%B2%D0%B0%D0%B8%20%D0%BD%D0%B0%D1%8F%D1%80%D0%B8%D0%B2%D0%B0%D0%B8&artista=%D0%BB%D1%8E%D0%B1%D1%8D
```
Ok, data in utf8. We parsed encoding from headers of server response.
Continue, check next lyrics source:
```
lyrics : loading http://lyrics.wikia.com/%D0%9B%D1%8E%D0%B1%D1%8D:%D0%94%D0%B0%D0%B2%D0%B0%D0%B9%20%D0%BD%D0%B0%D1%8F%D1%80%D0%B8%D0%B2%D0%B0%D0%B9
Error fetching http://lyrics.wikia.com/%D0%9B%D1%8E%D0%B1%D1%8D:%D0%94%D0%B0%D0%B2%D0%B0%D0%B9%20%D0%BD%D0%B0%D1%8F%D1%80%D0%B8%D0%B2%D0%B0%D0%B9 : HTTP/1.1 404 Not Found
*** unhandled exception in callback:
***   Wide character in subroutine entry at /usr/local/lib/perl5/Encode.pm line 200, <$OUTPUTfh> line 806.
***  ignoring at gmusicbrowser.pl line 1670, <$OUTPUTfh> line 806.
```
halt and don't go to the next lyrics source (musixmatch).
I think, this happen because data contain cyrillic characters.
```
Загрузка не удалась. <a href="http://lyrics.wikia.com/%D0%90%D0%BB%D0%B5%D0%BA%D1%81%D0%B0%D0%BD%D0%B4%D1%80%20%D0%9F%D1%83%D1%88%D0%BD%D0%BE%D0%B9:%D0%98%D0%B7%20%D1%83%D0%BC%D0%B0%20%D0%B4%D1%80%D1%83%D0%B6%D0%BE%D0%BA%20%D0%BD%D0%B5%20%D0%B8%D0%B4%D1%91%D1%82">повторить попытку</a>
```
Cyrillic characters appear in function "loaded":
```perl
unless ($data) { # our case: server response is "404 Not Found"
    $data=_("Loading failed.").qq( <a href="$self->{url}">)._("retry").'</a>'; $type="text/html";
}
```
"Loading failed/retry" after localization turns into cyrillic "Загрузка не удалась/повторить попытку".
And the error happens because after we set 1252(encoding of the **Latin** alphabet) as default encoding and try to decode localized data.

I suggest to not decoding data which not received from server.

-------------
P.S. Add please
```perl
use open qw(:std :utf8);
```
pragma to gmusicbrowser.pl. Otherwise displayed many warnings in this case:
```
$ LANG=ru_RU perl gmusicbrowser.pl -listplugin
...
Wide character in warn at gmusicbrowser.pl line 1615.
RIP : Рип CD
Wide character in warn at gmusicbrowser.pl line 1615.
TitleBar : Заголовок
Wide character in warn at gmusicbrowser.pl line 1615.
WebContext : Веб-контекст
```
or this
```
$  LANG=ru_RU perl gmusicbrowser.pl -listcmd   
```
etc.

Thank you very much.
