### PR TITLE
Improve Dutch translation

### DIFF
--- a/gmusicbrowser.pl
+++ b/gmusicbrowser.pl
@@ -6185,7 +6185,7 @@ sub AboutDialog
 		'Korean : bluealbum',
 		'Russian : tin',
 		'Italian : Michele Giampaolo',
-		'Dutch : Gijs Timmers',
+		'Dutch : Gijs Timmers, M1dgard',
 		'Japanese : Sunatomo',
 		'Serbian : Саша Петровић',
 		'Finnish : Jiri Grönroos',

--- a/gmusicbrowser_list.pm
+++ b/gmusicbrowser_list.pm
@@ -1637,12 +1637,12 @@ my @sort_menu_append=
 
 our @MenuPageOptions;
 my @MenuSubGroup=
-(	{ label => sub {_("Set subgroup").' '.$_[0]{depth}},	submenu => sub { return {0 => _"None",map {$_=>Songs::FieldName($_)} Songs::FilterListFields()}; },
+(	{ label => sub {sprintf _("Set subgroup %d"), $_[0]{depth}},	submenu => sub { return {0 => _"None",map {$_=>Songs::FieldName($_)} Songs::FilterListFields()}; },
 	  first_key=> "0",	submenu_reverse => 1,
 	  code	=> sub { $_[0]{self}->SetField($_[1],$_[0]{depth}) },
 	  check	=> sub { $_[0]{self}{field}[$_[0]{depth}] ||0 },
 	},
-	{ label => sub {_("Options for subgroup").' '.$_[0]{depth}},	submenu => \@MenuPageOptions,
+	{ label => sub {sprintf _("Options for subgroup %d"), $_[0]{depth}},	submenu => \@MenuPageOptions,
 	  test  => sub { $_[0]{depth} <= $_[0]{self}{depth} },
 	},
 );

--- a/layouts/shimmer.layout
+++ b/layouts/shimmer.layout
@@ -123,7 +123,7 @@ KeyBindings	= Escape CloseWindow
 #####################################
 
 {Group discleft}
-title=disc on the left side
+title= _"Disc on the left side"
 head=3
 left=width
 vcollapse=head+title:h+line:h+2
@@ -132,7 +132,7 @@ width:	OptionNumber(default=15,min=10,max=100,step=1)
 line: line(x1=1,y1=1,x2=$_w,y2=1,color='#ccc',width=1)
 
 {Group artistalbum_breadcrumbs}
-title=album and artist breadcrumbs
+title= _"Album and artist breadcrumbs"
 head=title:h
 tail=25
 vcollapse=head

--- a/po/nl.po
+++ b/po/nl.po
@@ -5,8 +5,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gmusicbrowser 1.1008\n"
 "Report-Msgid-Bugs-To: squentin@free.fr\n"
-"POT-Creation-Date: 2015-12-28 17:38+0100\n"
-"PO-Revision-Date: 2015-12-28 23:43+0100\n"
+"POT-Creation-Date: 2015-12-29 15:39+0100\n"
+"PO-Revision-Date: 2015-12-29 16:07+0100\n"
 "Last-Translator: Midgard <@M1dgard on GitHub>\n"
 "Language-Team: Nederlands <@M1dgard on GitHub>\n"
 "Language: nl\n"
@@ -373,6 +373,9 @@ msgstr "Album"
 msgid "Album and artist"
 msgstr "Album en artiest"
 
+msgid "Album and artist breadcrumbs"
+msgstr "Album-en-artiest-broodkruimels"
+
 msgid "Album and artist on the left side"
 msgstr "Album en artiest aan de linkerzijde"
 
@@ -660,7 +663,7 @@ msgid "Bad session"
 msgstr "Ongeldige sessie"
 
 msgid "Base Folder :"
-msgstr "Standaardmap:"
+msgstr "Hoofdmap:"
 
 msgid "Basic fields"
 msgstr "Standaardvelden"
@@ -1123,6 +1126,9 @@ msgstr "Schijfnr."
 msgid "Disc name"
 msgstr "Schijfnaam"
 
+msgid "Disc on the left side"
+msgstr "Schijfnummer aan de linkerzijde"
+
 msgid "Display (:1 or host:0 for example)"
 msgstr "Toon (:1 of host:0 bijvoorbeeld)"
 
@@ -1303,13 +1309,13 @@ msgid "Enqueue Action"
 msgstr "Actie in wachtrij plaatsen"
 
 msgid "Enqueue Displayed"
-msgstr "Plaats de getoonde in de wachtrij"
+msgstr "Getoonde in wachtrij plaatsen"
 
 msgid "Enqueue Selected"
-msgstr "Plaats de geselecteerde in de wachtrij"
+msgstr "Geselecteerde in wachtrij plaatsen"
 
 msgid "Enqueue Selected Songs"
-msgstr "Plaats de geselecteerde nummers in de wachtrij"
+msgstr "De geselecteerde nummers in de wachtrij plaatsen"
 
 msgid "Enqueue Songs from Current Album"
 msgstr "Nummers van het huidige album in de wachtrij plaatsen"
@@ -1573,7 +1579,7 @@ msgid "Folders to search for new songs"
 msgstr "Mappen om in te zoeken naar nieuwe nummers:"
 
 msgid "Follow playing song"
-msgstr "Nummer volgen tijdens afspelen"
+msgstr "Volg steeds nummer dat afgespeeld wordt"
 
 msgid "Follow selected song"
 msgstr "Geselecteerd nummer volgen"
@@ -1589,6 +1595,11 @@ msgstr "Voor kommagetallen"
 
 msgid "For integer numbers"
 msgstr "Voor gehele getallen"
+
+msgid "For when values are likely to be repeated"
+msgstr ""
+"Voor als het waarschijnlijk is dat dezelfde waarden bij veel verschillende "
+"nummers gebruikt worden"
 
 msgid "Forward"
 msgstr "Volgende"
@@ -2413,10 +2424,11 @@ msgid "Options"
 msgstr "Opties"
 
 msgid "Options ..."
-msgstr "Opties..."
+msgstr "Opties ..."
 
-msgid "Options for subgroup"
-msgstr "Opties voor subgroep"
+#, perl-format
+msgid "Options for subgroup %d"
+msgstr "Opties voor subgroep %d"
 
 msgid ""
 "Or you can use the field $files which will be replaced by the list of files, "
@@ -2586,6 +2598,9 @@ msgstr "Afspeel- en wachtrijpictogrammen"
 #, perl-brace-format
 msgid "Playing error : {error}"
 msgstr "Afspeelfout: {error}"
+
+msgid "Playing/Queue Icon or Track"
+msgstr "Nu-aan-het-afspelen/In-wachtrij-pictogram of tracknummer"
 
 msgid "Playlist"
 msgstr "Afspeellijst"
@@ -3343,8 +3358,9 @@ msgstr "Afbeelding instellen met dit bestand"
 msgid "Set player window layout"
 msgstr "Afspeelvensterlayout instellen"
 
-msgid "Set subgroup"
-msgstr "Subgroep instellen"
+#, perl-format
+msgid "Set subgroup %d"
+msgstr "Subgroep %d instellen"
 
 #, perl-brace-format
 msgid "Set {year} as year for all tracks on this album."
@@ -3953,7 +3969,7 @@ msgid "Use {command} to play {ext} files"
 msgstr "{command} gebruiken om {ext}-bestanden af te spelen"
 
 msgid "Used for clipping prevention"
-msgstr "Gebruikt om storing te vermijden"
+msgstr "Vermijdt storing"
 
 msgid "Used for the Artists field"
 msgstr "Gebruikt voor het 'Artiest'-veld"
@@ -4170,7 +4186,7 @@ msgid "_Insert column"
 msgstr "_Kolom invoegen"
 
 msgid "_Remove this column"
-msgstr "_Deze kolom verwijderen"
+msgstr "Kolom _verwijderen"
 
 msgid "_Retry"
 msgstr "_Opnieuw proberen"
@@ -4290,7 +4306,7 @@ msgid "bonus tracks"
 msgstr "bonusnummers"
 
 msgid "boolean"
-msgstr "boolean"
+msgstr "booleaanse waarde (waar/vals)"
 
 msgid "bootleg"
 msgstr "bootleg"
@@ -4343,10 +4359,10 @@ msgid "command :"
 msgstr "opdracht:"
 
 msgid "common number"
-msgstr "algemeen getal"
+msgstr "getal met suggesties van eerdere waarden"
 
 msgid "common string"
-msgstr "algeme tekenreeks"
+msgstr "tekenreeks met suggesties van eerdere waarden"
 
 msgid "composer"
 msgstr "componist"
@@ -4506,7 +4522,7 @@ msgid "flags"
 msgstr "vlaggen"
 
 msgid "float"
-msgstr "drijvend"
+msgstr "kommagetal"
 
 msgid "font size depends on"
 msgstr "tekstgrootte is afhankelijk van"
@@ -4537,7 +4553,7 @@ msgid "group by"
 msgstr "groeperen op"
 
 msgid "half-life : "
-msgstr "halfleven:"
+msgstr "halfwaardetijd:"
 
 msgid "has a picture"
 msgstr "heeft een afbeelding"
@@ -4612,7 +4628,7 @@ msgid "includes artist %s"
 msgstr "bevat artiest %s"
 
 msgid "integer"
-msgstr "getal"
+msgstr "geheel getal"
 
 msgid "interview"
 msgstr "interview"

--- a/po/nl.po
+++ b/po/nl.po
@@ -6,14 +6,15 @@ msgstr ""
 "Project-Id-Version: gmusicbrowser 1.1008\n"
 "Report-Msgid-Bugs-To: squentin@free.fr\n"
 "POT-Creation-Date: 2012-02-02 17:04+0100\n"
-"PO-Revision-Date: 2012-03-16 22:35+0100\n"
-"Last-Translator: Gijs Timmers <gijs.timmers@student.kuleuven.be>\n"
+"PO-Revision-Date: 2015-12-28 19:21+0100\n"
+"Last-Translator: M1dgard\n"
 "Language-Team: Nederlands <gijs.timmers@student.kuleuven.be>\n"
-"Language: \n"
+"Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bits\n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n!=1);\n"
+"X-Generator: Poedit 1.5.4\n"
 
 msgid " Context pane layout "
 msgstr "Contextpaneellayout"
@@ -50,8 +51,8 @@ msgstr[1] "%d artiesten"
 #, perl-format
 msgid "%d Song"
 msgid_plural "%d Songs"
-msgstr[0] "%d titel"
-msgstr[1] "%d titels"
+msgstr[0] "%d nummer"
+msgstr[1] "%d nummers"
 
 #, perl-format
 msgid "%d Upcoming Event"
@@ -98,32 +99,32 @@ msgstr[1] "%d seconden"
 #, perl-format
 msgid "%d song"
 msgid_plural "%d songs"
-msgstr[0] "%d titel"
-msgstr[1] "%d titels"
+msgstr[0] "%d nummer"
+msgstr[1] "%d nummers"
 
 #, perl-format
 msgid "%d song added"
 msgid_plural "%d songs added"
-msgstr[0] "%d titel toegevoegd"
-msgstr[1] "%d titels toegevoegd"
+msgstr[0] "%d nummer toegevoegd"
+msgstr[1] "%d nummers toegevoegd"
 
 #, perl-format
 msgid "%d song in queue"
 msgid_plural "%d songs in queue"
-msgstr[0] "%d titel in wachtri"
-msgstr[1] "%d titels in wachtrij"
+msgstr[0] "%d nummer in wachtri"
+msgstr[1] "%d nummers in wachtrij"
 
 #, perl-format
 msgid "%d song in the library"
 msgid_plural "%d songs in the library"
-msgstr[0] "%d titel in de bibliotheek"
-msgstr[1] "%d titels in de bibliotheek"
+msgstr[0] "%d nummer in de bibliotheek"
+msgstr[1] "%d nummers in de bibliotheek"
 
 #, perl-format
 msgid "%d song selected"
 msgid_plural "%d songs selected"
-msgstr[0] "%d titel geselecteerd"
-msgstr[1] "%d titels geselecteerd"
+msgstr[0] "%d nummer geselecteerd"
+msgstr[1] "%d nummers geselecteerd"
 
 #, perl-format
 msgid "%t by %a (%m)"
@@ -136,8 +137,8 @@ msgstr "'{file}' bestaat al. Wilt u dit bestand overschrijven?"
 #, perl-format
 msgid "(%d song excluded)"
 msgid_plural "(%d songs excluded)"
-msgstr[0] "(%d titel uitgesloten)"
-msgstr[1] "(%d titels uitgesloten)"
+msgstr[0] "(%d nummer uitgesloten)"
+msgstr[1] "(%d nummers uitgesloten)"
 
 msgid "(applied after restart)"
 msgstr "(vereist een herstart)"
@@ -163,7 +164,7 @@ msgid ""
 "not in it\n"
 "- Skip to another song when removing the current song from the playlist"
 msgstr ""
-"- Als u een nummer selecteert die niet in de afspeellijst staat, zal de "
+"- Als u een nummer selecteert dat niet in de afspeellijst staat, zal de "
 "afspeellijstfilter gereset worden\n"
 "- Spring naar een ander nummer wanneer het huidige nummer verwijderd wordt "
 "uit de afspeellijst"
@@ -176,22 +177,22 @@ msgstr "0 betekent 'toon alles'"
 
 #, perl-brace-format
 msgid "1 chance in {probability}"
-msgstr "1 kans in {probability}"
+msgstr "1 kans op {probability}"
 
 msgid "3 Filter panes"
-msgstr "3 Filterpaneel"
+msgstr "3 filterpaneel"
 
 msgid "32x32 PNG file icon"
 msgstr "Bestandspictogram van 32×32 pixels, in PNG-formaat"
 
 msgid "50 Last Added"
-msgstr "50 laatst toegevoegd"
+msgstr "50 laatst toegevoegde"
 
 msgid "50 Last Played"
-msgstr "50 laatst afgespeeld"
+msgstr "50 laatst afgespeelde"
 
 msgid "50 Most Played"
-msgstr "50 meest afgespeeld"
+msgstr "50 meest afgespeelde"
 
 msgid "<Unknown>"
 msgstr "<Onbekend>"
@@ -236,7 +237,7 @@ msgid ""
 msgstr "Weet u zeker dat u {files} wilt verwijderen?"
 
 msgid "About to turn off the computer in :"
-msgstr "Zal de computer afsluiten over:"
+msgstr "De computer wordt afgesloten over:"
 
 msgid "Actions are not supported by current notification daemon"
 msgstr ""
@@ -246,7 +247,7 @@ msgid "Add"
 msgstr "Voeg toe"
 
 msgid "Add Files ..."
-msgstr "Bestanden toevoegen..."
+msgstr "Bestanden toevoegen ..."
 
 msgid "Add Music"
 msgstr "Muziek toevoegen"
@@ -262,14 +263,14 @@ msgstr "Voeg een knop toe om over te schakelen op volledig scherm"
 
 msgid "Add a fullscreen button to layouts that can accept extra buttons"
 msgstr ""
-"Voeg een volledig scherm-knop toe aan de layouts die het plaatsen van extra "
+"Voeg een volledigschermknop toe aan de layouts die het plaatsen van extra "
 "knoppen ondersteunen"
 
 msgid "Add a group"
 msgstr "Groep toevoegen"
 
 msgid "Add a label to the current song"
-msgstr "Label toevoegen aan het huidige titel"
+msgstr "Label toevoegen aan het huidige nummer"
 
 msgid "Add a list of files/folders to the playlist"
 msgstr "Voeg een lijst van bestanden of mappen toe aan de afspeellijst"
@@ -287,7 +288,7 @@ msgid "Add folder"
 msgstr "Map toevoegen"
 
 msgid "Add folder ..."
-msgstr "Map toevoegen..."
+msgstr "Map toevoegen ..."
 
 msgid "Add label"
 msgstr "Label toevoegen"
@@ -341,15 +342,15 @@ msgid ""
 " dates more recent than number1 seconds will use format1, ..."
 msgstr ""
 "Eventueel kan de volgende opmaak gebruikt worden:\n"
-" standaard titel1 opmaak1 titel2 opmaak2...\n"
-" gegevens recenter dan titel1 seconden zullen opmaak1 gebruiken,..."
+" standaard getal1 opmaak1 getal2 opmaak2...\n"
+" gegevens recenter dan getal1 seconden zullen opmaak1 gebruiken, ..."
 
 msgid ""
 "Adds a menu entry to artist/album context menu, allowing to search the "
 "picture/cover in google and save it."
 msgstr ""
-"Voegt een menu-item toe aan het artiest-/albumcontextmenu, welke toelaat om "
-"de afbeelding te zoeken met Google, om deze vervolgens op te slaan."
+"Voegt een menu-item toe aan het artiest-/albumcontextmenu, dat toelaat om de "
+"albumhoes te zoeken op internet, om deze vervolgens op te slaan."
 
 msgid "Adds labels to the current song"
 msgstr "Voegt een label toe aan het huidige nummer."
@@ -358,7 +359,7 @@ msgid "Adds menu entries to song contextual menu"
 msgstr "Voegt menu-items toe aan het contextmenu van het nummer."
 
 msgid "Advanced Search ..."
-msgstr "Geavanceerd zoeken..."
+msgstr "Geavanceerd zoeken ..."
 
 msgid "Advanced Tag Editing"
 msgstr "Geavanceerd tags bewerken"
@@ -429,7 +430,7 @@ msgid "All"
 msgstr "Alle"
 
 msgid "All Songs"
-msgstr "Alle titels"
+msgstr "Alle nummers"
 
 msgid "All albums"
 msgstr "Alle albums"
@@ -453,7 +454,7 @@ msgid "All of :"
 msgstr "Alles van:"
 
 msgid "All songs"
-msgstr "Alle titels"
+msgstr "Alle nummers"
 
 msgid "All styles"
 msgstr "Alle stijlen"
@@ -609,7 +610,7 @@ msgstr "Automatisch afbeeldingen selecteren"
 
 msgid "Automatically remove current song if not found"
 msgstr ""
-"Verwijder de huidige titel uit de afspeellijst indien deze niet gevonden "
+"Verwijder het huidige nummer uit de afspeellijst indien het niet gevonden "
 "wordt."
 
 msgid "Autosave"
@@ -661,7 +662,7 @@ msgid "Browser views"
 msgstr "Browserweergaven"
 
 msgid "Browser window layout :"
-msgstr "Browservensterlayout:"
+msgstr "Lay-out van browservenster:"
 
 msgid "Browser with SongTree"
 msgstr "Browser met boomweergave"
@@ -670,7 +671,7 @@ msgid "Buttons"
 msgstr "Knoppen"
 
 msgid "Buttons, Song & Cover"
-msgstr "Knoppen, titel en albumafbeelding"
+msgstr "Knoppen, nummer en albumhoes"
 
 msgid "Can be relative by using + or -"
 msgstr "Kan worden aangepast met + en -"
@@ -751,10 +752,10 @@ msgid "Check Collection"
 msgstr "Controleer de verzameling"
 
 msgid "Check for updated/deleted songs on startup"
-msgstr "Controleer op geüpdatete/verwijderde titels bij het opstarten"
+msgstr "Controleer op geüpdatete/verwijderde nummers bij het opstarten"
 
 msgid "Check for updated/removed songs"
-msgstr "Controleer op geüpdatete/verwijderde titels"
+msgstr "Controleer op geüpdatete/verwijderde nummers"
 
 msgid "Check real length of mp3"
 msgstr "Controleer de lengte van het mp3-bestand"
@@ -763,13 +764,13 @@ msgid "Checking length/bitrate"
 msgstr "Controleert lengte/bitsnelheid"
 
 msgid "Checking songs"
-msgstr "Controleert titels"
+msgstr "Controleert nummers"
 
 msgid "Choose Album From this Artist"
 msgstr "Kies een album van deze artiest"
 
 msgid "Choose Artist/Album/Song"
-msgstr "Kies een artiest/album/titel"
+msgstr "Kies een artiest/album/nummer"
 
 msgid "Choose Picture"
 msgstr "Kies een afbeelding"
@@ -846,25 +847,26 @@ msgid "Collection"
 msgstr "Verzameling"
 
 msgid "Command"
-msgstr "Opdracht"
+msgstr "Commando"
 
 msgid "Command to launch when the button is pressed"
-msgstr "Uit te voeren opdracht wanneer de knop wordt ingedrukt"
+msgstr "Uit te voeren commando wanneer de knop wordt ingedrukt"
 
 msgid ""
 "Command used when\n"
 "'turn off computer when queue empty'\n"
 "is selected"
 msgstr ""
-"Gebruikte opdracht wanneer\n"
+"Gebruikt commando als\n"
 "'sluit de computer af zodra de wachrij leeg is'\n"
 "geselecteerd is"
 
 msgid "Command when playing song changed :"
-msgstr "Uit te voeren opdracht zodra de titel die afgespeeld wordt, verandert:"
+msgstr ""
+"Uit te voeren commando zodra het nummer dat afgespeeld wordt, verandert:"
 
 msgid "Command when stopped :"
-msgstr "Uit te voeren opdracht zodra de titel stopt:"
+msgstr "Uit te voeren opdracht zodra het nummer stopt:"
 
 msgid "Comment"
 msgstr "Opmerking"
@@ -924,7 +926,7 @@ msgid "Copyright"
 msgstr "Copyright"
 
 msgid "Cover Size : "
-msgstr "Albumafmetingen:"
+msgstr "Albumhoesgrootte:"
 
 msgid "Create ID3v2 tags as ID3v2.4"
 msgstr "Maak ID3v2 tags als ID3v2.4"
@@ -935,7 +937,7 @@ msgid "Ctrl"
 msgstr "Ctrl"
 
 msgid "Current song must always be in the playlist"
-msgstr "Huidige titel moet altijd in de afspeellijst staan"
+msgstr "Huidig nummer moet altijd in de afspeellijst staan"
 
 msgid "Custom"
 msgstr "Gebruikergedefinieerd"
@@ -962,7 +964,7 @@ msgid "Custom pipeline"
 msgstr "Gebruikergedefinieerde pipeline"
 
 msgid "Custom..."
-msgstr "Anders..."
+msgstr "Anders ..."
 
 msgid "Date"
 msgstr "Datum"
@@ -1008,7 +1010,7 @@ msgid "Delete"
 msgstr "Verwijderen"
 
 msgid "Delete Selected Songs"
-msgstr "Verwijder de geselecteerde titels"
+msgstr "Verwijder de geselecteerde nummers"
 
 msgid "Delete list"
 msgstr "Verwijder de lijst"
@@ -1030,7 +1032,7 @@ msgstr "Bureaubladwidgetsplugin"
 
 msgid "Disable screensaver when fullscreen and playing"
 msgstr ""
-"Schakel de schermbeveiliging uit wanneer een titel afspeelt in volledig "
+"Schakel de schermbeveiliging uit wanneer een nummer afspeelt in volledig "
 "scherm"
 
 msgid "Disabled"
@@ -1046,10 +1048,10 @@ msgid "Disc name"
 msgstr "Schijfnaam"
 
 msgid "Display (:1 or host:0 for example)"
-msgstr "Toon (:1 of gastheer:0 bijvoorbeeld)"
+msgstr "Toon (:1 of host:0 bijvoorbeeld)"
 
 msgid "Display Songs"
-msgstr "Toon titels"
+msgstr "Toon nummers"
 
 msgid ""
 "Display a special layout in or around the titlebar of the focused window"
@@ -1057,10 +1059,10 @@ msgstr ""
 "Gebruik een speciale layout in of rond de titelbalk van het actieve venster"
 
 msgid "Display stop/next actions"
-msgstr "Toon stop/volgende acties"
+msgstr "Toon knoppen voor stop/volgende"
 
 msgid "Display synchronized lyrics of the current song"
-msgstr "Toon gesynchroniseerde songtekst van de huidige titel"
+msgstr "Toon gesynchroniseerde songtekst van het huidige nummer"
 
 #, perl-format
 msgid "Display tray tip for %d ms"
@@ -1070,7 +1072,7 @@ msgid "Do not add a title row"
 msgstr "Geen titelregel toevoegen"
 
 msgid "Do not add songs that can't be played"
-msgstr "Geen titels toevoegen die niet afgespeeld kunnen worden"
+msgstr "Geen nummers toevoegen die niet afgespeeld kunnen worden"
 
 msgid "Do not create an id3v1 tag in mp3 files"
 msgstr "Maak geen ID3v1-tag in mp3-bestanden"
@@ -1095,13 +1097,13 @@ msgid "Don't submit current song"
 msgstr "Huidig nummer niet indienen"
 
 msgid "Drag and drop songs here to replace the selection."
-msgstr "Titels hierheen slepen om de selectie te vervangen"
+msgstr "Nummers hierheen slepen om de selectie te vervangen"
 
 msgid "Edit"
 msgstr "Bewerken"
 
 msgid "Edit Current Song Properties"
-msgstr "Eigenschappen van de huidige titel bewerken"
+msgstr "Eigenschappen van het huidige nummer bewerken"
 
 msgid "Edit labels"
 msgstr "Labels bewerken"
@@ -1110,10 +1112,10 @@ msgid "Edit Lyrics"
 msgstr "Songtekst bewerken"
 
 msgid "Edit Lyrics ..."
-msgstr "Songtekst bewerken..."
+msgstr "Songtekst bewerken ..."
 
 msgid "Edit Multiple Songs Properties"
-msgstr "Eigenschappen van meerdere titels bewerken"
+msgstr "Eigenschappen van meerdere nummers bewerken"
 
 msgid "Edit rating"
 msgstr "Waardering bewerken"
@@ -1128,10 +1130,10 @@ msgid "Edit filter"
 msgstr "Filter bewerken"
 
 msgid "Edit filter..."
-msgstr "Filter bewerken..."
+msgstr "Filter bewerken ..."
 
 msgid "Edit grouping ..."
-msgstr "Groepering bewerken..."
+msgstr "Groepering bewerken ..."
 
 msgid "Edit in the last.fm wiki"
 msgstr "Bewerk in de last.fm-wiki"
@@ -1140,16 +1142,16 @@ msgid "Edit list"
 msgstr "Lijst bewerken"
 
 msgid "Edit ordered modes ..."
-msgstr "Modi voor geordend afspelen bewerken..."
+msgstr "Modi voor geordend afspelen bewerken ..."
 
 msgid "Edit random modes ..."
-msgstr "Modi voor willekeurig afspelen bewerken..."
+msgstr "Modi voor willekeurig afspelen bewerken ..."
 
 msgid "Edit selected song properties"
-msgstr "Eigenschappen van de huidige titel bewerken"
+msgstr "Eigenschappen van het huidige nummer bewerken"
 
 msgid "Edit..."
-msgstr "Bewerken..."
+msgstr "Bewerken ..."
 
 msgid "Editing list : "
 msgstr "Bewerklijst:"
@@ -1191,13 +1193,13 @@ msgid "Enqueue Selected"
 msgstr "Plaats de geselecteerde in de wachtrij"
 
 msgid "Enqueue Selected Songs"
-msgstr "Plaats de geselecteerde titels in de wachtrij"
+msgstr "Plaats de geselecteerde nummers in de wachtrij"
 
 msgid "Enqueue Songs from Current Album"
-msgstr "Titels van het huidige album in de wachtrij plaatsen"
+msgstr "Nummers van het huidige album in de wachtrij plaatsen"
 
 msgid "Enqueue Songs from Current Artist"
-msgstr "Titels van de huidige artiest in de wachtrij plaatsen"
+msgstr "Nummers van de huidige artiest in de wachtrij plaatsen"
 
 msgid "Enqueue a list of files/folders"
 msgstr "Lijst van bestanden of mappen in de wachtrij plaatsen"
@@ -1262,7 +1264,7 @@ msgstr "De auteur niet in de wachtlijst opnemen"
 
 msgid "Execute custom command on selected files"
 msgstr ""
-"Voer een gebruikersgedefinieerde opdracht uit op de geselecteerde bestanden"
+"Voer een gebruikersgedefinieerd commando uit op de geselecteerde bestanden"
 
 msgid "Export"
 msgstr "Exporteren"
@@ -1271,7 +1273,7 @@ msgid "Export plugin"
 msgstr "Plugin exporteren"
 
 msgid "Export song properties to a .csv file"
-msgstr "Titeleigenschappen exporteren naar een .csv-bestand"
+msgstr "Eigenschappen van nummer exporteren naar een .csv-bestand"
 
 msgid "Export to .m3u file"
 msgstr "Exporteren naar een .m3u-bestand"
@@ -1283,7 +1285,7 @@ msgid "Extra gain"
 msgstr "Extra versterking"
 
 msgid "Extract guest artist from title :"
-msgstr "Leid de medewerkende artiest af van de titel:"
+msgstr "Leid gastartiesten af uit de titel:"
 
 msgid "Fade-out"
 msgstr "Fade-out"
@@ -1355,7 +1357,7 @@ msgid "Filter on playing Artist"
 msgstr "Filter op basis van de nu afgespeelde artiest"
 
 msgid "Filter on playing Song"
-msgstr "Filter op basis van de nu afgespeelde titel"
+msgstr "Filter op basis van het nu afgespeelde nummer"
 
 msgid "Filter on this album"
 msgstr "Filter op basis van dit album"
@@ -1370,13 +1372,13 @@ msgid "Find a unique filename if file already exists"
 msgstr "Nieuwe bestandsnaam aanmaken, indien de bestandsnaam al bestaat"
 
 msgid "Find songs in same albums"
-msgstr "Titels in dezelfde albums zoeken"
+msgstr "Nummers in dezelfde albums zoeken"
 
 msgid "Find songs with same artists"
-msgstr "Titels met dezelfde artiesten zoeken"
+msgstr "Nummers met dezelfde artiesten zoeken"
 
 msgid "Find songs with the same names"
-msgstr "Titels met dezelfde namen zoeken"
+msgstr "Nummers met dezelfde titels zoeken"
 
 msgid "Folder"
 msgstr "Map"
@@ -1391,13 +1393,13 @@ msgid "Folder pattern :"
 msgstr "Mappatroon:"
 
 msgid "Folders to search for new songs"
-msgstr "Mappen om te doorzoeken voor nieuwe titels:"
+msgstr "Mappen om in te zoeken naar nieuwe nummers:"
 
 msgid "Follow playing song"
-msgstr "Afgespeelde titel volgen"
+msgstr "Afgespeeld nummer volgen"
 
 msgid "Follow selected song"
-msgstr "Geselecteerde titel volgen"
+msgstr "Geselecteerd nummer volgen"
 
 msgid "Font size"
 msgstr "Lettergrootte"
@@ -1412,7 +1414,7 @@ msgid "Friday"
 msgstr "Vrijdag"
 
 msgid "Full screen layout :"
-msgstr "Volledig schermweergave:"
+msgstr "Lay-out van volledigschermweergave:"
 
 msgid "Fullscreen"
 msgstr "Volledig scherm"
@@ -1424,7 +1426,7 @@ msgid "GStreamer module not loaded."
 msgstr "GStreamer-module niet ingeladen"
 
 msgid "Gain for songs missing replaygain tags"
-msgstr "Versterking voor titels die geen ReplayGain-tags hebben"
+msgstr "Versterking voor nummers die geen ReplayGain-tags hebben"
 
 msgid "Garage Fullscreen"
 msgstr "Volledig scherm in Garagemodus"
@@ -1454,10 +1456,10 @@ msgid "Gnome multimedia keys plugin"
 msgstr "Gnome-multimediatoetsenplugin"
 
 msgid "Go to Playing Track"
-msgstr "Naar de huidige titel gaan"
+msgstr "Naar huidig nummer gaan"
 
 msgid "Go to playing song"
-msgstr "Naar de huidige titel gaan"
+msgstr "Naar huidig nummer gaan"
 
 msgid "Group by :"
 msgstr "Groeperen op:"
@@ -1502,7 +1504,7 @@ msgid ""
 "In this case one command by file will be run\n"
 "\n"
 msgstr ""
-"In dit geval zal een opdracht per bestand worden uitgevoerd\n"
+"In dit geval zal één commando per bestand worden uitgevoerd\n"
 "\n"
 
 msgid "Include Styles in Genres"
@@ -1524,10 +1526,10 @@ msgid "Insensitive title-artist (right-aligned)"
 msgstr "Titel - Artiest (rechts uitgelijnd, niet-klikbaar)"
 
 msgid "Insensitive, Song & Cover"
-msgstr "Niet-klikbaar, titel en albumhoes"
+msgstr "Niet-klikbaar, nummer en albumhoes"
 
 msgid "Insert Selected Songs at the top of the queue"
-msgstr "Geselecteerde titels bovenaan in de wachtrij plaatsen"
+msgstr "Geselecteerde nummers bovenaan in de wachtrij plaatsen"
 
 msgid "Insert a list of files/folders at the start of the playlist"
 msgstr "Lijst van bestanden of mappen bovenaan de wachtrij plaatsen"
@@ -1603,13 +1605,13 @@ msgid "Launch ripping program"
 msgstr "Programma om CD's te rippen starten"
 
 msgid "Layout"
-msgstr "Opmaak"
+msgstr "Lay-out"
 
 msgid "Layout :"
-msgstr "Opmaak:"
+msgstr "Lay-out:"
 
 msgid "Layouts"
-msgstr "Opmaken"
+msgstr "Opmaak"
 
 msgid "Left aligned"
 msgstr "Links uitgelijnd"
@@ -1643,8 +1645,8 @@ msgstr ""
 #, perl-format
 msgid "Library size : %d song"
 msgid_plural "Library size : %d songs"
-msgstr[0] "Bibliotheek: %d titel"
-msgstr[1] "Bibliotheek: %d titels"
+msgstr[0] "Bibliotheek: %d nummer"
+msgstr[1] "Bibliotheek: %d nummers"
 
 msgid "Limit similar artists to a rate of similarity : "
 msgstr "Gelijkaardige artiesten begrenzen tot een graad van gelijkaardigheid:"
@@ -1665,7 +1667,7 @@ msgid "Listed : "
 msgstr "In de lijst opgenomen:"
 
 msgid "Listed songs"
-msgstr "In de lijst opgenomen titels"
+msgstr "In de lijst opgenomen nummers"
 
 msgid "Listeners: "
 msgstr "Luisteraars"
@@ -1688,8 +1690,8 @@ msgstr "Artiestinfo laden of opslaan in:"
 #, perl-format
 msgid "Loaded %d unsent song from previous session"
 msgid_plural "Loaded %d unsent songs from previous session"
-msgstr[0] "%d niet-verzonden titel uit de vorige sessie ingeladen"
-msgstr[1] "%d niet-verzonden titels uit de vorige sessie ingeladen"
+msgstr[0] "%d niet-verzonden nummer uit de vorige sessie ingeladen"
+msgstr[1] "%d niet-verzonden nummers uit de vorige sessie ingeladen"
 
 msgid "Loading failed."
 msgstr "Laden mislukt."
@@ -1713,7 +1715,7 @@ msgid "Lock on Artist"
 msgstr "Op artiest vergrendelen"
 
 msgid "Lock on song"
-msgstr "Op titel vergrendelen"
+msgstr "Op nummer vergrendelen"
 
 #, perl-brace-format
 msgid "Lock on {field}"
@@ -1834,7 +1836,7 @@ msgid "Minimum size"
 msgstr "Minimumafmetingen"
 
 msgid "Misc."
-msgstr "Anders"
+msgstr "Varia"
 
 msgid "Modification"
 msgstr "Wijziging"
@@ -1876,13 +1878,13 @@ msgid "Music"
 msgstr "Muziek"
 
 msgid "Mute/Unmute"
-msgstr "Demping aan-/uitschakelen"
+msgstr "Demping in-/uitschakelen"
 
 msgid "Name"
 msgstr "Naam"
 
 msgid "Name of layout"
-msgstr "Opmaaknaam"
+msgstr "Naam van lay-out"
 
 msgid "Name under which the command will appear in the menu"
 msgstr "Naam waaronder de opdracht zal verschijnen in het menu"
@@ -1915,10 +1917,10 @@ msgid "Next Artist"
 msgstr "Volgende artiest"
 
 msgid "Next Song"
-msgstr "Volgende titel"
+msgstr "Volgend nummer"
 
 msgid "Next Song In Playlist"
-msgstr "Volgende titel in afspeellijst"
+msgstr "Volgend nummer in afspeellijst"
 
 msgid "No connections"
 msgstr "Geen verbinding"
@@ -1954,10 +1956,10 @@ msgid "No review written."
 msgstr "Geen recensie gevonden."
 
 msgid "No songs"
-msgstr "Geen titels"
+msgstr "Geen nummers"
 
 msgid "No songs found"
-msgstr "Geen titels gevonden"
+msgstr "Geen nummers gevonden"
 
 msgid "No sound menu found"
 msgstr "Geen geluidsmenu gevonden"
@@ -2009,14 +2011,14 @@ msgstr "Notificatieplugin"
 
 msgid "Notify you of the playing song with the system's notification popups"
 msgstr ""
-"Met behulp van de systeemnotificatiedaemon notificatiepopups geven over de "
-"huidige titel"
+"Met behulp van de systeemnotificatiedaemon notificatiepopups geven over het "
+"huidige nummer"
 
 msgid "Now playing"
-msgstr "U luistert naar"
+msgstr "Nu aan het afspelen"
 
 msgid "NowPlaying plugin"
-msgstr "U luistert naar-plugin"
+msgstr "Nu-aan-het-afspelen-plugin"
 
 msgid "Number of days since added"
 msgstr "Aantal dagen sinds toevoeging"
@@ -2145,10 +2147,10 @@ msgid "Open link in Browser"
 msgstr "Link openen in webbrowser"
 
 msgid "Open page layout"
-msgstr "Paginaopmaak openen"
+msgstr "Paginalay-out openen"
 
 msgid "Open special layouts as desktop widgets"
-msgstr "Speciale opmaken als desktopwidgets openen"
+msgstr "Speciale lay-outs als desktopwidgets openen"
 
 msgid "Open this page in the web browser"
 msgstr "Deze pagina in de webbrowser openen"
@@ -2235,19 +2237,19 @@ msgid "Play"
 msgstr "Afspelen"
 
 msgid "Play Only Displayed"
-msgstr "Enkel de getoonde afspelen"
+msgstr "Enkel getoonde nummers afspelen"
 
 msgid "Play Only Selected"
-msgstr "Enkel de geselecteerde afspelen"
+msgstr "Enkel geselecteerde nummers afspelen"
 
 msgid "Play a list of files"
 msgstr "Een lijst van bestanden afspelen"
 
 msgid "Play all songs from this album"
-msgstr "Alle titels van dit album afspelen"
+msgstr "Alle nummers van dit album afspelen"
 
 msgid "Play all songs from this artist"
-msgstr "Alle titels van deze artiest afspelen"
+msgstr "Alle nummers van deze artiest afspelen"
 
 msgid "Play button"
 msgstr "Afspeelknop"
@@ -2262,7 +2264,7 @@ msgid "Play filter"
 msgstr "Afspeelfilter"
 
 msgid "Play listed songs"
-msgstr "Titels in de lijst afspelen"
+msgstr "Nummers in de lijst afspelen"
 
 msgid "Play order"
 msgstr "Afspeelvolgorde"
@@ -2283,10 +2285,10 @@ msgid "Player mounted on :"
 msgstr "Speler aangekoppeld om:"
 
 msgid "Player window layout :"
-msgstr "Afspeelvensteropmaak:"
+msgstr "Lay-out van afspeelvenster:"
 
 msgid "Playing"
-msgstr "Spelend"
+msgstr "Afspelen"
 
 msgid "Playing Album"
 msgstr "Nu afgespeeld album"
@@ -2380,10 +2382,10 @@ msgid "Previous"
 msgstr "Vorige"
 
 msgid "Previous Song"
-msgstr "Vorige titel"
+msgstr "Vorig nummer"
 
 msgid "Previous Song In Playlist"
-msgstr "Vorige titel in afspeellijst"
+msgstr "Vorig nummer in afspeellijst"
 
 msgid "Previous page"
 msgstr "Vorige pagina"
@@ -2486,7 +2488,7 @@ msgid "Rating range:"
 msgstr "Waarderingsbereik:"
 
 msgid "Re-load layouts"
-msgstr "Opmaken opnieuw inladen"
+msgstr "Lay-outs opnieuw inladen"
 
 msgid "Re-read tags"
 msgstr "Tags opnieuw inlezen"
@@ -2510,17 +2512,17 @@ msgid "Recent artists"
 msgstr "Recente artiesten"
 
 msgid "Recent songs"
-msgstr "Recente titels"
+msgstr "Recente nummers"
 
 msgid "Recent songs include skipped songs that haven't been played."
 msgstr ""
-"'Recente titels' bevat ook overgeslagen titels die niet zijn afgespeeld"
+"'Recente nummers' bevat ook overgeslagen nummers die niet zijn afgespeeld"
 
 msgid "Recently played"
 msgstr "Recent afgespeeld"
 
 msgid "Recently played songs"
-msgstr "Recent afgespeelde titels"
+msgstr "Recent afgespeelde nummers"
 
 msgid "Record label"
 msgstr "Platenlabel"
@@ -2563,7 +2565,7 @@ msgid "Remember playing position between sessions"
 msgstr "Afspeelpositie bewaren tussen verschillende sessies"
 
 msgid "Remember playing song between sessions"
-msgstr "Afspelende titel bewaren tussen verschillende sessies"
+msgstr "Nummer dat wordt afgespeeld onthouden tussen verschillende sessies"
 
 msgid "Remember queue between sessions"
 msgstr "Wachtrij bewaren tussen verschillende sessies"
@@ -2575,13 +2577,13 @@ msgid "Remove"
 msgstr "Verwijderen"
 
 msgid "Remove a label from the current song"
-msgstr "Een label van de huidige titel verwijderen"
+msgstr "Een label van het huidige nummer verwijderen"
 
 msgid "Remove all"
 msgstr "Alle verwijderen"
 
 msgid "Remove all songs"
-msgstr "Alle titels verwijderen"
+msgstr "Alle nummers verwijderen"
 
 msgid "Remove filter"
 msgstr "Filter verwijderen"
@@ -2611,7 +2613,7 @@ msgid "Remove list"
 msgstr "Lijst verwijderen"
 
 msgid "Remove selected songs"
-msgstr "Geselecteerde titels verwijderen"
+msgstr "Geselecteerde nummers verwijderen"
 
 msgid "Remove this field"
 msgstr "Dit veld verwijderen"
@@ -2717,7 +2719,7 @@ msgid "Right-click to remove filters"
 msgstr "Rechtsklikken om filters te verwijderen"
 
 msgid "Right-click to toggle shuffle/random"
-msgstr "Rechtsklikken om willekeurig afspelen aan-/ of uit te zetten"
+msgstr "Rechtsklikken om willekeurig afspelen aan of uit te zetten"
 
 msgid "Rip"
 msgstr "Rippen"
@@ -2729,7 +2731,7 @@ msgid "Ripping software :"
 msgstr "Ripprogramma:"
 
 msgid "Run a command when playing a song"
-msgstr "Opdracht uitvoeren wanneer een titel wordt afgespeeld"
+msgstr "Commando uitvoeren wanneer een nummer wordt afgespeeld"
 
 msgid "Run perl code"
 msgstr "Perl-code uitvoeren"
@@ -2839,10 +2841,10 @@ msgid "Scanning"
 msgstr "Inlezen"
 
 msgid "Scroll with song"
-msgstr "Titel volgen"
+msgstr "Nummer volgen"
 
 msgid "Scroll with the song"
-msgstr "Titel volgen"
+msgstr "Nummer volgen"
 
 msgid "Scrollwheel to change, right-click to mute"
 msgstr ""
@@ -2918,7 +2920,7 @@ msgid "Search for current artist"
 msgstr "Huidige artiest opzoeken"
 
 msgid "Search for new songs on startup"
-msgstr "Controleer op geüpdatete titels bij het opstarten"
+msgstr "Zoek naar nieuwe nummers bij het opstarten"
 
 msgid "Search google for Artist"
 msgstr "Artiest op Google opzoeken"
@@ -2936,7 +2938,7 @@ msgid "Search title"
 msgstr "Titel zoeken"
 
 msgid "Search window layout :"
-msgstr "Afspeelvensteropmaak:"
+msgstr "Lay-out van zoekvenster:"
 
 msgid "Search:"
 msgstr "Zoeken:"
@@ -2948,7 +2950,7 @@ msgid "Seek"
 msgstr "Zoeken"
 
 msgid "Select current song"
-msgstr "Huidige titel selecteren"
+msgstr "Huidige nummer selecteren"
 
 msgid "Select fields"
 msgstr "Velden selecteren"
@@ -2966,10 +2968,10 @@ msgid "Selected : "
 msgstr "Geselecteerd:"
 
 msgid "Selected songs"
-msgstr "Geselecteerde titels"
+msgstr "Geselecteerde nummers"
 
 msgid "Selected songs to update :"
-msgstr "Te updateten titels:"
+msgstr "Te updaten nummers:"
 
 msgid "Selecting pictures"
 msgstr "Selecteert afbeeldingen"
@@ -2978,10 +2980,10 @@ msgid "Seller"
 msgstr "Verkoper"
 
 msgid "Send Title/Artist/Album in standard input"
-msgstr "Titel/artiest/album in standaardinvoer opsturen"
+msgstr "Titel/artiest/album naar standaardinvoer doorsturen"
 
 msgid "Set Current Song Rating"
-msgstr "Huidige titel waarderen"
+msgstr "Huidig nummer waarderen"
 
 msgid "Set Picture"
 msgstr "Afbeelding instellen"
@@ -3021,8 +3023,8 @@ msgid ""
 "songs filenames) are available)"
 msgstr ""
 "Terminalopdracht\n"
-"(U kunt bepaalde variabelen, zoals %f (bestandsnaam van de huidige titel) en "
-"%F (lijst van bestandsnamen van de geselecteerde titels) gebruiken)"
+"(U kunt bepaalde variabelen, zoals %f (bestandsnaam van het huidige nummer) "
+"en %F (lijst van bestandsnamen van de geselecteerde nummers) gebruiken)"
 
 #. Shift key
 msgctxt "Keyboard"
@@ -3072,7 +3074,7 @@ msgid "Show similar artists"
 msgstr "Vergelijkbare artiesten tonen"
 
 msgid "Show song details"
-msgstr "Details van huidige titel tonen"
+msgstr "Details van huidig nummer tonen"
 
 msgid "Show status bar"
 msgstr "Statusbalk tonen"
@@ -3087,7 +3089,7 @@ msgid "Show tray icon"
 msgstr "Systeemvakpictogram tonen"
 
 msgid "Show tray tip on song change"
-msgstr "Systeemvaknotificatie tonen bij het afspelen van een nieuwe titel"
+msgstr "Systeemvaknotificatie tonen bij het afspelen van een nieuw nummer"
 
 msgid "Show/Hide"
 msgstr "Tonen/Verbergen"
@@ -3114,13 +3116,13 @@ msgid "Shuffle"
 msgstr "Willekeurige volgorde"
 
 msgid "Shuffle queue"
-msgstr "Titels in wachtrij in willekeurige volgorde plaatsen"
+msgstr "Nummers in wachtrij in willekeurige volgorde plaatsen"
 
 msgid "Shuffled albums"
 msgstr "Albums in willekeurige volgorde"
 
 msgid "Shuffled albums, shuffled tracks"
-msgstr "Albums en titels in willekeurige volgorde"
+msgstr "Albums en nummers in willekeurige volgorde"
 
 msgid "Shutdown command :"
 msgstr "Afsluitcommando:"
@@ -3147,7 +3149,7 @@ msgid "Skip count"
 msgstr "Aantal keer overgeslagen"
 
 msgid "Skip to next song if an error occurs"
-msgstr "Naar de volgende titel springen als er een fout optreedt"
+msgstr "Naar het volgende nummer springen als er een fout optreedt"
 
 msgid "Small"
 msgstr "Klein"
@@ -3162,22 +3164,22 @@ msgid "Smaller browser"
 msgstr "Kleinere browser"
 
 msgid "Song"
-msgstr "Titel"
+msgstr "Nummer"
 
 msgid "Song Properties"
-msgstr "Titeleigenschappen"
+msgstr "Eigenschappen van nummer"
 
 msgid "Song informations"
-msgstr "Titelinformatie"
+msgstr "Informatie over nummer"
 
 msgid "Song rating"
-msgstr "Titelwaardering"
+msgstr "Waardering"
 
 msgid "SongTree groupings edition"
 msgstr "Bestandsboomgroepering aanpassen"
 
 msgid "Songs Properties"
-msgstr "Titeleigenschappen"
+msgstr "Eigenschappen van nummers"
 
 msgid "Songtree View"
 msgstr "Lijstweergave met kleine albumhoezen"
@@ -3246,7 +3248,7 @@ msgid "Submit failed : "
 msgstr "Indienen mislukt:"
 
 msgid "Submit played songs to last.fm"
-msgstr "Afgespeelde titels indienen op last.fm"
+msgstr "Afgespeelde nummers indienen op last.fm"
 
 msgid "Subtitle"
 msgstr "Ondertitel"
@@ -3302,8 +3304,8 @@ msgstr ""
 #, perl-format
 msgid "This label is set for %d song."
 msgid_plural "This label is set for %d songs."
-msgstr[0] "Dit label is ingesteld voor %d titel."
-msgstr[1] "Dit label is ingesteld voor %d titels."
+msgstr[0] "Dit label is ingesteld voor %d nummer."
+msgstr[1] "Dit label is ingesteld voor %d nummers."
 
 msgid "This plugin requires :"
 msgstr "Pluginvereisten:"
@@ -3317,7 +3319,7 @@ msgstr ""
 
 #, perl-format
 msgid "Threshold to count a song as played : %d %"
-msgstr "Drempelwaarde om een titel als 'afgespeeld' te bestempelen: %d%"
+msgstr "Drempelwaarde om een nummer als 'afgespeeld' te bestempelen: %d%"
 
 msgid "Thursday"
 msgstr "Donderdag"
@@ -3350,7 +3352,7 @@ msgstr "Titel: %t"
 
 #, perl-format
 msgid "Title: %t (Track No. %n)"
-msgstr "Titel: %t (titelnr %n)"
+msgstr "Titel: %t (tracknr. %n)"
 
 msgid "Titlebar"
 msgstr "Titelbalk"
@@ -3359,25 +3361,25 @@ msgid "Titlebar overlay plugin"
 msgstr "Titelbalkoverlayplugin"
 
 msgid "Toggle Album Lock"
-msgstr "Albumvergrendeling aan- of uitzetten"
+msgstr "Albumvergrendeling in- of uitschakelen"
 
 msgid "Toggle Artist Lock"
-msgstr "Artiestvergrendeling aan- of uitzetten"
+msgstr "Artiestvergrendeling in- of uitschakelen"
 
 msgid "Toggle Song Lock"
-msgstr "Titelvergrendeling aan- of uitzetten"
+msgstr "Nummervergrendeling in- of uitschakelen"
 
 msgid "Toggle a label of the current song"
-msgstr "Label toevoegen aan de huidige titel"
+msgstr "Label toevoegen aan of verwijderen van het huidige nummer"
 
 msgid "Toggle between Random/Shuffle and Ordered"
-msgstr "Omschakelen tussen geordend en willekeurig afspelen"
+msgstr "Wisselen tussen geordend en willekeurig afspelen"
 
 msgid "Toggle fullscreen mode"
-msgstr "Volledig schermweergave aan- of uitschakelen"
+msgstr "Volledig schermweergave in- of uitschakelen"
 
 msgid "Toggle the fullscreen layout"
-msgstr "Volledig schermweergave aan- of uitschakelen"
+msgstr "Volledig schermweergave in- of uitschakelen"
 
 msgid "Toolbar"
 msgstr "Werkbalk"
@@ -3389,19 +3391,19 @@ msgid "Total playcount:"
 msgstr "Aantal keer afgespeeld:"
 
 msgid "Track"
-msgstr "Titel"
+msgstr "Tracknummer"
 
 msgid "Track Properties"
-msgstr "Titeleigenschappen"
+msgstr "Eigenschappen van nummer"
 
 msgid "Track gain"
-msgstr "Titelvolumeversterking"
+msgstr "Volumeversterking van nummer"
 
 msgid "Track peak"
-msgstr "Titelpiekwaarde"
+msgstr "Piekwaarde van nummer"
 
 msgid "Tray tip window layout :"
-msgstr "Systeemvaknotificatieopmaak:"
+msgstr "Opmaak van systeemvaknotificatie:"
 
 msgid "Tuesday"
 msgstr "Dinsdag"
@@ -3448,10 +3450,10 @@ msgid "Untitled"
 msgstr "Naamloos"
 
 msgid "Update tags"
-msgstr "Updatet tags"
+msgstr "Tags updaten"
 
 msgid "Update tags..."
-msgstr "Updatet tags..."
+msgstr "Tags updaten..."
 
 msgid "Upper left"
 msgstr "Linksboven"
@@ -3483,8 +3485,8 @@ msgstr "Hoofdfilter gebruiken"
 
 msgid "Use album normalization instead of track normalization"
 msgstr ""
-"Albumgeluidsversterkingsnormalisatie in plaats van "
-"titelgeluidsversterkingnormalisatie gebruiken"
+"Geluidsversterkingsnormalisatie voor album in plaats van voor individueel "
+"nummer gebruiken"
 
 msgid "Use default regular expression"
 msgstr "Standaard reguliere expressie gebruiken"
@@ -3507,7 +3509,7 @@ msgstr ""
 "%startDate<br>in %city, %country<br><br>'"
 
 msgid "Use the playing filter"
-msgstr "Nu gebruikte filter gebruiken"
+msgstr "Filter gebruiken"
 
 #, perl-brace-format
 msgid "Use this picture as cover for album '{album}'"
@@ -3562,14 +3564,14 @@ msgid "Volume step :"
 msgstr "Volumestapsgrootte:"
 
 msgid "Wait for more when queue empty"
-msgstr "Op meer titels wachten indien de wachtrij leeg is"
+msgstr "Op meer nummers wachten indien de wachtrij leeg is"
 
 msgid ""
 "Warning : these are advanced options, don't change them unless you know what "
 "you are doing."
 msgstr ""
 "Waarschuwing: dit zijn geavanceerde opties. Verander hier niets aan, tenzij "
-"u weet, waar u mee bezig bent."
+"u weet waar u mee bezig bent."
 
 msgid "Warning : using a folder with invalid encoding, you should rename it."
 msgstr ""
@@ -3607,11 +3609,11 @@ msgid ""
 "When changing songs, the previous song is added to the recent list even if "
 "not played at all."
 msgstr ""
-"Indien aangevinkt, zal de vorige titel worden toegevoegd aan de lijst "
-"'Recent afgespeeld', ook indien deze titel overgeslagen werd."
+"Indien aangevinkt, zal het vorige nummer worden toegevoegd aan de lijst "
+"'Recent afgespeeld', ook indien het overgeslagen werd."
 
 msgid "When current song"
-msgstr "Waneer deze titel afgespeeld wordt"
+msgstr "Waneer dit nummer afgespeeld wordt"
 
 msgid "Whole library"
 msgstr "Gehele bibliotheek"
@@ -3807,7 +3809,7 @@ msgid "big size"
 msgstr "groot"
 
 msgid "bonus tracks"
-msgstr "bonustitels"
+msgstr "bonusnummers"
 
 msgid "boolean"
 msgstr "boolean"
@@ -3981,7 +3983,7 @@ msgstr "bijvoorbeeld:"
 
 #, perl-brace-format
 msgid "example (selected song) : {score}  ({chances})"
-msgstr "bijvoorbeeld (geselecteerde titel): {score} ({chances})"
+msgstr "bijvoorbeeld (geselecteerd nummer): {score} ({chances})"
 
 msgid "example : "
 msgstr "voorbeeld:"
@@ -4244,7 +4246,7 @@ msgid "left-side filter panes"
 msgstr "filterpanelen aan de linkerzijde"
 
 msgid "length of songs"
-msgstr "lengte van de titels"
+msgstr "lengte van nummers"
 
 msgid "less than"
 msgstr "minder dan"
@@ -4361,7 +4363,7 @@ msgid "no plugins found"
 msgstr "geen plugins gevonden"
 
 msgid "no songs needs checking"
-msgstr "geen enkele titel moet nagekeken worden"
+msgstr "geen enkel nummer moet nagekeken worden"
 
 msgid "no splitting"
 msgstr "geen splitsing"
@@ -4411,13 +4413,13 @@ msgid "not the %s most recent"
 msgstr "niet de recentste %s"
 
 msgid "number of songs"
-msgstr "aantal titels"
+msgstr "aantal nummers"
 
 msgid "number of songs in filter"
-msgstr "aantal titels in filter"
+msgstr "aantal nummers in filter"
 
 msgid "only show entries with at least n songs"
-msgstr "alleen items tonen met minstens n titels"
+msgstr "alleen items tonen met minstens n nummers"
 
 msgid "only works when the artist-info tab is displayed"
 msgstr "werkt alleen wanneer de artiestinfotab ingeschakeld is"
@@ -4638,13 +4640,13 @@ msgid "title"
 msgstr "titel"
 
 msgid "toggle Intersection mode"
-msgstr "intersectiemodus aan- of uitschakelen"
+msgstr "intersectiemodus in- of uitschakelen"
 
 msgid "toggle Invert mode"
-msgstr "omkeermodus aan- of uitschakelen"
+msgstr "omkeermodus in- of uitschakelen"
 
 msgid "tools"
-msgstr "gereecdschap"
+msgstr "gereedschap"
 
 msgid "true"
 msgstr "waar"
@@ -4677,16 +4679,16 @@ msgid "use album name"
 msgstr "albumnaam gebruiken"
 
 msgid "use default"
-msgstr "standaardinstelling gebruiken"
+msgstr "standaardwaarde gebruiken"
 
 msgid "use gnome settings"
 msgstr "Gnome-instellingen gebruiken"
 
 msgid "use song folder"
-msgstr "bijbehorende map van de titel gebruiken"
+msgstr "bijbehorende map van nummer gebruiken"
 
 msgid "use standard strftime variables"
-msgstr "standaard strftimevariabelen gebruiken"
+msgstr "standaard strftime-variabelen gebruiken"
 
 msgid "username :"
 msgstr "gebruikersnaam:"
@@ -4695,7 +4697,7 @@ msgid "using skin :"
 msgstr "gebruikt uiterlijk:"
 
 msgid "wait for more"
-msgstr "op meer wachten"
+msgstr "wachten op meer"
 
 msgid "weeks"
 msgstr "weken"
@@ -4812,4 +4814,4 @@ msgid "{song} by {artist}"
 msgstr "{song} door {artist}"
 
 msgid "|-separated list of widget names"
-msgstr "met '|' gescheide widgetnaamlijst"
+msgstr "widgetnaamlijst, items gescheiden door |"

--- a/po/nl.po
+++ b/po/nl.po
@@ -5,8 +5,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gmusicbrowser 1.1008\n"
 "Report-Msgid-Bugs-To: squentin@free.fr\n"
-"POT-Creation-Date: 2012-02-02 17:04+0100\n"
-"PO-Revision-Date: 2015-12-28 19:21+0100\n"
+"POT-Creation-Date: 2015-12-28 17:38+0100\n"
+"PO-Revision-Date: 2015-12-28 22:26+0100\n"
 "Last-Translator: M1dgard\n"
 "Language-Team: Nederlands <gijs.timmers@student.kuleuven.be>\n"
 "Language: nl\n"
@@ -29,9 +29,6 @@ msgstr "Herziening"
 msgid " of {length}"
 msgstr "van {length}"
 
-msgid "# songs"
-msgstr "# nummers"
-
 #, perl-format
 msgid "%S by %a"
 msgstr "%S door %a"
@@ -47,12 +44,6 @@ msgid "%d Artist"
 msgid_plural "%d Artists"
 msgstr[0] "%d artiest"
 msgstr[1] "%d artiesten"
-
-#, perl-format
-msgid "%d Song"
-msgid_plural "%d Songs"
-msgstr[0] "%d nummer"
-msgstr[1] "%d nummers"
 
 #, perl-format
 msgid "%d Upcoming Event"
@@ -127,6 +118,16 @@ msgstr[0] "%d nummer geselecteerd"
 msgstr[1] "%d nummers geselecteerd"
 
 #, perl-format
+msgid "%d song waiting to be sent"
+msgid_plural "%d songs waiting to be sent"
+msgstr[0] "%d nummers in wachtri"
+msgstr[1] "%d nummers in wachtrij"
+
+#, perl-format
+msgid "%s fuzzy match with %s"
+msgstr "%s lijkt op %s"
+
+#, perl-format
 msgid "%t by %a (%m)"
 msgstr "%t door %a (%m)"
 
@@ -140,8 +141,10 @@ msgid_plural "(%d songs excluded)"
 msgstr[0] "(%d nummer uitgesloten)"
 msgstr[1] "(%d nummers uitgesloten)"
 
-msgid "(applied after restart)"
-msgstr "(vereist een herstart)"
+msgid "(The middle-click action doesn't work correctly in some desktops)"
+msgstr ""
+"(Klikken met de middelste muisknop wordt niet correct afgehandeld op "
+"bepaalde computers)"
 
 msgid "(case insensitive)"
 msgstr "(hoofdletterongevoelig)"
@@ -221,9 +224,6 @@ msgstr "Afbreken"
 msgid "Abort ReplayGain analysis"
 msgstr "Stop de ReplayGain-analyse"
 
-msgid "Abort all"
-msgstr "Breek alles af"
-
 msgid "Abort mass-tagging"
 msgstr "Breek massatagging af"
 
@@ -238,6 +238,9 @@ msgstr "Weet u zeker dat u {files} wilt verwijderen?"
 
 msgid "About to turn off the computer in :"
 msgstr "De computer wordt afgesloten over:"
+
+msgid "Action"
+msgstr "Actie"
 
 msgid "Actions are not supported by current notification daemon"
 msgstr ""
@@ -290,9 +293,6 @@ msgstr "Map toevoegen"
 msgid "Add folder ..."
 msgstr "Map toevoegen ..."
 
-msgid "Add label"
-msgstr "Label toevoegen"
-
 msgid "Add multiple condition"
 msgstr "Meerdere voorwaarden instellen"
 
@@ -301,6 +301,9 @@ msgstr "Nieuw label toevoegen"
 
 msgid "Add new radio"
 msgstr "Nieuw radiokanaal toevoegen"
+
+msgid "Add picture"
+msgstr "Afbeelding toevoegen"
 
 msgid "Add rule : "
 msgstr "Regel toevoegen:"
@@ -316,9 +319,6 @@ msgstr "Toevoegen aan bestaande waarden"
 
 msgid "Add to list"
 msgstr "Aan lijst toevoegen"
-
-msgid "Add to playlist"
-msgstr "Aan afspeellijst toevoegen"
 
 msgid "Add to queue"
 msgstr "Aan wachtrij toevoegen"
@@ -358,6 +358,9 @@ msgstr "Voegt een label toe aan het huidige nummer."
 msgid "Adds menu entries to song contextual menu"
 msgstr "Voegt menu-items toe aan het contextmenu van het nummer."
 
+msgid "Advanced"
+msgstr "Geavanceerd"
+
 msgid "Advanced Search ..."
 msgstr "Geavanceerd zoeken ..."
 
@@ -379,8 +382,14 @@ msgstr "Albumartiest"
 msgid "Album artist or artist"
 msgstr "Albumartiest of artiest"
 
+msgid "Album cover"
+msgstr "Albumhoes"
+
 msgid "Album gain"
 msgstr "Volumeversterking van het album"
+
+msgid "Album has picture"
+msgstr "Album heeft hoes"
 
 msgid "Album mode"
 msgstr "Albummodus"
@@ -464,7 +473,7 @@ msgstr "Alle thema's"
 
 msgid ""
 "Allmusic uses both Genres and Styles to describe albums. If you use only "
-"Genres, you may want to include Styles in the list of Genres."
+"Genres, you may want to include Styles in allmusic's list of Genres."
 msgstr ""
 "'Alle muziek' gebruikt zowel 'Genres' als 'Stijlen' om albums te "
 "beschrijven. Indien u enkel 'Genres' gebruikt, zou u 'Stijlen' kunnen "
@@ -486,11 +495,27 @@ msgctxt "Keyboard"
 msgid "Alt"
 msgstr "Alt"
 
+msgid "Always"
+msgstr "Altijd"
+
 msgid "Amount of volume changed by the mouse wheel"
 msgstr "Stel in hoe sterk het volume wijzigt bij gebruik van het muiswieltje."
 
+msgid ""
+"Analyse and add replaygain tags for all songs that don't have replaygain "
+"tags, or incoherent album replaygain tags"
+msgstr ""
+"Analyseer nummers zonder ReplayGain-tags of albums met incoherente tags, en "
+"voeg ReplayGain-tags toe"
+
 msgid "Any of :"
 msgstr "Een van:"
+
+msgid "App Indicator plugin"
+msgstr "App-indicator-plug-in"
+
+msgid "App indicator"
+msgstr "App-indicator"
 
 msgid "Append"
 msgstr "Toevoegen"
@@ -523,15 +548,18 @@ msgstr "Artiest (Jaar - Album)"
 msgid "Artist Biography"
 msgstr "Artiestbiografie"
 
-#, perl-format
-msgid "Artist Picture Size : %d"
-msgstr "Grootte van de artiestafbeelding: %d"
-
 msgid "Artist URL"
 msgstr "Artiest-URL"
 
+msgid "Artist has picture"
+msgstr "Artiest heeft afbeelding"
+
 msgid "Artist picture"
 msgstr "Artiestafbeelding"
+
+#, perl-format
+msgid "Artist picture size : %d"
+msgstr "Grootte van de artiestafbeelding: %d"
 
 msgid "Artist playcount:"
 msgstr "Aantal keer artiest afgespeeld:"
@@ -676,6 +704,9 @@ msgstr "Knoppen, nummer en albumhoes"
 msgid "Can be relative by using + or -"
 msgstr "Kan worden aangepast met + en -"
 
+msgid "Can be searched with :"
+msgstr "Kan doorzocht worden met:"
+
 msgid "Can't change the volume in non-gstreamer iceserver mode"
 msgstr "Kan het volume niet veranderen in non-gstreamer-iceservermodus."
 
@@ -687,20 +718,15 @@ msgstr ""
 "het volume te veranderen als u deze audiobackend gebruikt."
 
 #, perl-brace-format
-msgid ""
-"Can't create Folder '{path}' : \n"
-"{error}"
-msgstr ""
-"Kan de map '{path}' niet aanmaken: \n"
-"{error}"
+msgid "Can't create folder: {path}"
+msgstr "Kan de map '{path}' niet aanmaken"
 
 #, perl-brace-format
 msgid "Can't create sink '{sink}'"
 msgstr "Kan de bestemming '{sink}' niet aanmaken"
 
-#, perl-brace-format
-msgid "Can't play '{file}'."
-msgstr "Kan '{file}' niet afspelen."
+msgid "Can't play this file."
+msgstr "Kan dit bestand niet afspelen."
 
 msgid "Can't read file or invalid file"
 msgstr "Het bestand is ongeldig of onleesbaar."
@@ -708,6 +734,9 @@ msgstr "Het bestand is ongeldig of onleesbaar."
 #, perl-brace-format
 msgid "Can't write in base folder '{folder}'."
 msgstr "Kan niet schrijven in de standaardmap '{folder}'"
+
+msgid "Cancel"
+msgstr "Annuleren"
 
 msgid "Capitalize"
 msgstr "Laat met hoofdletter beginnen"
@@ -759,6 +788,9 @@ msgstr "Controleer op geüpdatete/verwijderde nummers"
 
 msgid "Check real length of mp3"
 msgstr "Controleer de lengte van het mp3-bestand"
+
+msgid "Check your audio settings"
+msgstr "Controleer je audio-instellingen"
 
 msgid "Checking length/bitrate"
 msgstr "Controleert lengte/bitsnelheid"
@@ -816,6 +848,9 @@ msgstr "Kies de afspeellijstbestanden die geïmporteerd moeten worden"
 msgid "Clear"
 msgstr "Wissen"
 
+msgid "Clear playlist"
+msgstr "Afspeellijst wissen"
+
 msgid "Clear playlist filter"
 msgstr "Afspeellijstfilter wissen"
 
@@ -827,6 +862,9 @@ msgstr "Geselecteerde velden wissen"
 
 msgid "Click to show fullsize image"
 msgstr "Klik om de afbeelding op volledige grootte te zien"
+
+msgid "Click to show larger image"
+msgstr "Klik voor grotere afbeelding"
 
 msgid "Client banned, contact gmusicbrowser's developer"
 msgstr "Cliënt verbannen, neem contact op met de maker van gmusicbrowser."
@@ -852,6 +890,15 @@ msgstr "Commando"
 msgid "Command to launch when the button is pressed"
 msgstr "Uit te voeren commando wanneer de knop wordt ingedrukt"
 
+msgid "Command to open folders :"
+msgstr "Commando om mappen te openen:"
+
+msgid "Command to open urls :"
+msgstr "Commando om URL's te openen:"
+
+msgid "Command used :"
+msgstr "Gebruikt commando:"
+
 msgid ""
 "Command used when\n"
 "'turn off computer when queue empty'\n"
@@ -860,6 +907,9 @@ msgstr ""
 "Gebruikt commando als\n"
 "'sluit de computer af zodra de wachrij leeg is'\n"
 "geselecteerd is"
+
+msgid "Command used:"
+msgstr "Gebruikt commando:"
 
 msgid "Command when playing song changed :"
 msgstr ""
@@ -881,7 +931,7 @@ msgid "Composer"
 msgstr "Componist"
 
 msgid "Conductor"
-msgstr "Documenteerder"
+msgstr "Dirigent"
 
 msgid "Connect through a proxy"
 msgstr "Verbind via een proxy"
@@ -891,6 +941,9 @@ msgstr "Verbindingen van:"
 
 msgid "Context"
 msgstr "Context"
+
+msgid "Continue anyway"
+msgstr "Toch doorgaan"
 
 msgid "Control"
 msgstr "Controle"
@@ -910,11 +963,17 @@ msgstr "Kopiëren mislukt"
 msgid "Copy link address"
 msgstr "Kopieer URL"
 
+msgid "Copy missing values from previous line"
+msgstr "Kopieer ontbrekende waarden van vorige lijn"
+
 msgid "Copy to mounted portable player"
 msgstr "Kopieer naar de verbonden draagbare mediaspeler"
 
 msgid "Copy to portable player"
 msgstr "Kopieer naar de mediaspeler"
+
+msgid "Copying"
+msgstr "Kopiëren"
 
 #, perl-format
 msgid "Copying file"
@@ -953,9 +1012,6 @@ msgstr "Gebruikergedefinieerde opdracht:"
 
 msgid "Custom context pages :"
 msgstr "Gebruikergedefinieerde contextpanelen:"
-
-msgid "Custom fields"
-msgstr "Gebruikergedefinieerde velden"
 
 msgid "Custom formats"
 msgstr "Gebruikergedefinieerde opmaak"
@@ -1012,8 +1068,17 @@ msgstr "Verwijderen"
 msgid "Delete Selected Songs"
 msgstr "Verwijder de geselecteerde nummers"
 
+msgid "Delete file"
+msgstr "Bestand verwijderen"
+
 msgid "Delete list"
 msgstr "Verwijder de lijst"
+
+msgid "Delete preset"
+msgstr "Preset verwijderen"
+
+msgid "Deletion failed"
+msgstr "Verwijderen mislukt"
 
 msgid "Descending order"
 msgstr "Aflopende volgorde"
@@ -1029,6 +1094,14 @@ msgstr "Bureaubladwidgets"
 
 msgid "Desktop widgets plugin"
 msgstr "Bureaubladwidgetsplugin"
+
+#, perl-brace-format
+msgid "Destination: {file}"
+msgstr "Bestemming: {file}"
+
+#, perl-brace-format
+msgid "Destination: {folder}"
+msgstr "Bestemming: {folder}"
 
 msgid "Disable screensaver when fullscreen and playing"
 msgstr ""
@@ -1068,11 +1141,11 @@ msgstr "Toon gesynchroniseerde songtekst van het huidige nummer"
 msgid "Display tray tip for %d ms"
 msgstr "Toon een systeemvaknotificatie gedurende %d ms"
 
+msgid "Displays a panel indicator in some desktops"
+msgstr "Toont een paneelindicator op sommige computers"
+
 msgid "Do not add a title row"
 msgstr "Geen titelregel toevoegen"
-
-msgid "Do not add songs that can't be played"
-msgstr "Geen nummers toevoegen die niet afgespeeld kunnen worden"
 
 msgid "Do not create an id3v1 tag in mp3 files"
 msgstr "Maak geen ID3v1-tag in mp3-bestanden"
@@ -1096,17 +1169,26 @@ msgstr "Geen notificaties weergeven indien het hoofdvenster zichtbaar is"
 msgid "Don't submit current song"
 msgstr "Huidig nummer niet indienen"
 
+msgid "Download"
+msgstr "Download"
+
+msgid "Download failed."
+msgstr "Downloaden mislukt."
+
+msgid "Downloading"
+msgstr "Aan het downloaden"
+
 msgid "Drag and drop songs here to replace the selection."
 msgstr "Nummers hierheen slepen om de selectie te vervangen"
+
+msgid "Drop files in this folder"
+msgstr "Plaats bestanden in deze map"
 
 msgid "Edit"
 msgstr "Bewerken"
 
 msgid "Edit Current Song Properties"
 msgstr "Eigenschappen van het huidige nummer bewerken"
-
-msgid "Edit labels"
-msgstr "Labels bewerken"
 
 msgid "Edit Lyrics"
 msgstr "Songtekst bewerken"
@@ -1116,9 +1198,6 @@ msgstr "Songtekst bewerken ..."
 
 msgid "Edit Multiple Songs Properties"
 msgstr "Eigenschappen van meerdere nummers bewerken"
-
-msgid "Edit rating"
-msgstr "Waardering bewerken"
 
 msgid "Edit Settings"
 msgstr "Instellingen bewerken"
@@ -1138,8 +1217,14 @@ msgstr "Groepering bewerken ..."
 msgid "Edit in the last.fm wiki"
 msgstr "Bewerk in de last.fm-wiki"
 
+msgid "Edit labels"
+msgstr "Labels bewerken"
+
 msgid "Edit list"
 msgstr "Lijst bewerken"
+
+msgid "Edit mode"
+msgstr "Bewerken"
 
 msgid "Edit ordered modes ..."
 msgstr "Modi voor geordend afspelen bewerken ..."
@@ -1147,11 +1232,24 @@ msgstr "Modi voor geordend afspelen bewerken ..."
 msgid "Edit random modes ..."
 msgstr "Modi voor willekeurig afspelen bewerken ..."
 
+msgid "Edit rating"
+msgstr "Waardering bewerken"
+
+msgid "Edit row tip"
+msgstr "Tekst die verschijnt bij met de muis over nummer gaan bewerken"
+
 msgid "Edit selected song properties"
 msgstr "Eigenschappen van het huidige nummer bewerken"
 
+#, perl-brace-format
+msgid "Edit {field}"
+msgstr "{field} bewerken"
+
 msgid "Edit..."
 msgstr "Bewerken ..."
+
+msgid "Editable in song properties dialog"
+msgstr "Bewerkbaar in dialoogvenster \"Eigenschappen van nummer\""
 
 msgid "Editing list : "
 msgstr "Bewerklijst:"
@@ -1159,11 +1257,26 @@ msgstr "Bewerklijst:"
 msgid "Editing tags"
 msgstr "Bewerkt tags"
 
+msgid "Embedded Pictures"
+msgstr "Ingesloten afbeelding"
+
 msgid "Embedded lyrics"
 msgstr "Ingebouwde songtekst"
 
 msgid "Embedded picture"
 msgstr "Ingebouwde afbeelding"
+
+msgid "Embedded pictures"
+msgstr "Ingesloten afbeeldingen"
+
+msgid "Embedded pictures for this album"
+msgstr "Ingesloten afbeeldingen voor dit album"
+
+msgid "Embedded pictures in this folder"
+msgstr "Ingesloten afbeeldingen in deze map"
+
+msgid "Empty list"
+msgstr "Lege lijst"
 
 msgid "Encapsulated object"
 msgstr "Ingekapseld object"
@@ -1219,6 +1332,19 @@ msgstr "Equalizer"
 msgid "Error :"
 msgstr "Fout:"
 
+msgid "Error creating folder"
+msgstr "Fout tijdens het aanmaken van de map"
+
+msgid "Error details"
+msgstr "Details van fout"
+
+#, perl-brace-format
+msgid "Error opening '{file}' for writing."
+msgstr "Fout tijdens het openen van '{file}' om te schrijven."
+
+msgid "Error saving artistbio"
+msgstr "Fout tijdens het opslaan van de artiestenbiografie"
+
 #, perl-brace-format
 msgid ""
 "Error saving artistbio in '{file}' :\n"
@@ -1226,6 +1352,12 @@ msgid ""
 msgstr ""
 "Fout tijdens het opslaan van de artiestenbiografie in '{file}':\n"
 "{error}"
+
+msgid "Error saving icon"
+msgstr "Fout bij opslaan icoon"
+
+msgid "Error saving lyrics"
+msgstr "Fout tijdens het opslaan van de songtekst"
 
 #, perl-brace-format
 msgid ""
@@ -1235,6 +1367,12 @@ msgstr ""
 "Fout tijdens het opslaan van de songtekst in '{file}':\n"
 "{error}"
 
+msgid "Error saving picture"
+msgstr "Fout tijdens het opslaan van de afbeelding"
+
+msgid "Error saving review"
+msgstr "Fout tijdens het opslaan van de recensie"
+
 #, perl-brace-format
 msgid ""
 "Error saving review in '{file}' :\n"
@@ -1243,12 +1381,30 @@ msgstr ""
 "Fout tijdens het opslaan van de recensie in '{file}' :\n"
 "{error}"
 
+msgid "Error while writing replaygain data"
+msgstr "Fout tijdens het schrijven van ReplayGain-tags"
+
+msgid "Error while writing tag"
+msgstr "Fout tijdens het schrijven van tag"
+
 #, perl-brace-format
 msgid "Error writing '{file}'"
 msgstr "Fout tijdens het schrijven van '{file}'"
 
-msgid "Error writing replaygain tags :\n"
-msgstr "Fout tijdens het schrijven van ReplayGain-tags:\n"
+msgid "Error writing .csv file"
+msgstr "Fout tijdens het schrijven van CSV-bestand"
+
+msgid "Error writing .m3u file"
+msgstr "Fout tijdens het schrijven van M3U-bestand"
+
+msgid "Error writing downloaded file"
+msgstr "Fout tijdens het schrijven van gedownload bestand"
+
+msgid "Error writing lyrics"
+msgstr "Fout tijdens het schrijven van songteksten"
+
+msgid "Error writing tag"
+msgstr "Fout tijdens het schrijven van tag"
 
 msgid "Error: invalid filename pattern"
 msgstr "Fout: ongeldig bestandsnaampatroon"
@@ -1265,6 +1421,12 @@ msgstr "De auteur niet in de wachtlijst opnemen"
 msgid "Execute custom command on selected files"
 msgstr ""
 "Voer een gebruikersgedefinieerd commando uit op de geselecteerde bestanden"
+
+msgid "Exit"
+msgstr "Afsluiten"
+
+msgid "Exit full screen"
+msgstr "Volledigschermmodus verlaten"
 
 msgid "Export"
 msgstr "Exporteren"
@@ -1298,21 +1460,26 @@ msgid "Fade-out then stop"
 msgstr "Fade-out, daarna stoppen"
 
 #, perl-brace-format
-msgid ""
-"Failed to delete '{file}' :\n"
-"{error}"
-msgstr ""
-"Kon '{file}' niet verwijderen:\n"
-"{error}"
+msgid "Failed to delete '{file}'"
+msgstr "Kon '{file}' niet verwijderen"
 
-msgid "Field name"
-msgstr "Veldnaam"
+msgid "Fetching albuminfo"
+msgstr "Albuminfo ophalen"
+
+msgid "Field identifier"
+msgstr "Veld-id"
 
 msgid "Field type"
 msgstr "Veldtype"
 
 msgid "Fields"
 msgstr "Velden"
+
+msgid ""
+"Fields will be saved according to the settings above. Albuminfo files will "
+"be re-read if there are fields to be saved and you choose 'albums missing "
+"reviews' in the combo box."
+msgstr "Velden worden opgeslagen volgens de instellingen hierboven. "
 
 msgid "File"
 msgstr "Bestand"
@@ -1322,6 +1489,10 @@ msgstr "Bestandseigenschappen"
 
 msgid "File type"
 msgstr "Bestandstype"
+
+#, perl-brace-format
+msgid "File: {file}"
+msgstr "Bestand: {file}"
 
 msgid "Filename"
 msgstr "Bestandsnaam"
@@ -1337,6 +1508,9 @@ msgstr "Bestandsnaam zonder extensie"
 
 msgid "Files"
 msgstr "Bestanden"
+
+msgid "Files with these extensions won't be added"
+msgstr "Bestanden met deze extensies worden niet toegevoegd"
 
 msgid "Filesystem"
 msgstr "Bestandssysteem"
@@ -1369,7 +1543,7 @@ msgid "Find :"
 msgstr "Zoeken:"
 
 msgid "Find a unique filename if file already exists"
-msgstr "Nieuwe bestandsnaam aanmaken, indien de bestandsnaam al bestaat"
+msgstr "Unieke bestandsnaam genereren als de bestandsnaam al in gebruik is"
 
 msgid "Find songs in same albums"
 msgstr "Nummers in dezelfde albums zoeken"
@@ -1404,6 +1578,15 @@ msgstr "Geselecteerd nummer volgen"
 msgid "Font size"
 msgstr "Lettergrootte"
 
+msgid "For alternate ratings"
+msgstr "Voor alternatieve waarderingen"
+
+msgid "For decimal numbers"
+msgstr "Voor kommagetallen"
+
+msgid "For integer numbers"
+msgstr "Voor gehele getallen"
+
 msgid "Forward"
 msgstr "Volgende"
 
@@ -1412,6 +1595,17 @@ msgstr "Gevonden, maar werkt niet"
 
 msgid "Friday"
 msgstr "Vrijdag"
+
+#, perl-brace-format
+msgid ""
+"From: {oldname}\n"
+"To: {newname}"
+msgstr ""
+"Oude naam: {oldname}\n"
+"Nieuwe naam: {newname}"
+
+msgid "Full screen"
+msgstr "Volledig scherm"
 
 msgid "Full screen layout :"
 msgstr "Lay-out van volledigschermweergave:"
@@ -1482,11 +1676,14 @@ msgstr "Help"
 msgid "Hide"
 msgstr "Verbergen"
 
-msgid "Hide Artist/Album bar"
-msgstr "Verberg artiest-/albumpaneel"
+msgid "Hide non-matching"
+msgstr "Verberg niet-matchende nummers"
 
 msgid "Hide toolbar"
 msgstr "Werkbalk verbergen"
+
+msgid "High priority"
+msgstr "Hoge prioriteit"
 
 msgid "Icon theme :"
 msgstr "Pictogramthema:"
@@ -1494,11 +1691,31 @@ msgstr "Pictogramthema:"
 msgid "Identifier in file tag"
 msgstr "Identificatie in bestandstag"
 
+msgid ""
+"If one of these words is at the start of the string, it will be ignored when "
+"sorting most fields"
+msgstr ""
+"Als een van deze woorden aan het begin van een waarde staat, zal het worden "
+"genegeerd bij het sorteren van de meeste velden"
+
 msgid "Ignore playback errors"
 msgstr "Afspeelfouten negeren"
 
+msgid "Ignore these words when sorting :"
+msgstr "Negeer deze woorden bij het sorteren:"
+
+msgid "Ignored file extensions :"
+msgstr "Genegeerde bestandsextensies:"
+
 msgid "Import list"
 msgstr "Lijst importeren"
+
+msgid ""
+"Imports gstreamer presets, and synchronize modifications made with "
+"gmusicbrowser"
+msgstr ""
+"Gstreamer-presets importeren, en aanpassingen die u in gmusicbrowser maakt "
+"synchroniseren"
 
 msgid ""
 "In this case one command by file will be run\n"
@@ -1562,6 +1779,9 @@ msgstr "Karaoke"
 msgid "Karaoke plugin"
 msgstr "Karaokeplugin"
 
+msgid "Keep list filtered and sorted"
+msgstr "Lijst gefilterd en gesorteerd houden"
+
 msgid "Key"
 msgstr "Toets"
 
@@ -1594,6 +1814,9 @@ msgstr "Taal"
 
 msgid "Languages"
 msgstr "Talen"
+
+msgid "Last messages:"
+msgstr "Laatste berichten:"
 
 msgid "Last played"
 msgstr "Laatst afgespeeld"
@@ -1800,6 +2023,13 @@ msgid "Make it look like"
 msgstr "Vermommen als:"
 
 msgid ""
+"Makes gmusicbrowser monitor its pulseaudio volume, so that external changes "
+"to its volume are known."
+msgstr ""
+"Laat gmusicbrowser zijn pulseaudio-volume monitoren, zodat het externe "
+"invloeden aan zijn volume kent."
+
+msgid ""
 "Makes gmusicbrowser react to the Next/Previous/Play/Stop multimedia keys in "
 "gnome."
 msgstr ""
@@ -1820,6 +2050,9 @@ msgstr "Menu-itemnaam"
 
 msgid "Middle-clic for next album"
 msgstr "Middelklik voor volgend album"
+
+msgid "Middle-click action :"
+msgstr "Actie bij middelklik:"
 
 msgid ""
 "Middle-click on local artists to set a filter on them, right-click non-local "
@@ -1843,6 +2076,12 @@ msgstr "Wijziging"
 
 msgid "Monday"
 msgstr "Maandag"
+
+msgid "Monitor"
+msgstr "Monitor"
+
+msgid "Monitor the pulseaudio volume"
+msgstr "Monitor het pulseaudio-volume"
 
 msgid "Moods"
 msgstr "Stemmingen"
@@ -1868,6 +2107,9 @@ msgstr "Verplaatsen mislukt"
 msgid "Move folder to"
 msgstr "Map verplaatsen naar"
 
+msgid "Moving"
+msgstr "Verplaatsen"
+
 #, perl-format
 msgid "Moving file"
 msgid_plural "Moving %d files"
@@ -1876,6 +2118,9 @@ msgstr[1] "%d bestanden verplaatsen"
 
 msgid "Music"
 msgstr "Muziek"
+
+msgid "Music files"
+msgstr "Muziekbestanden"
 
 msgid "Mute/Unmute"
 msgstr "Demping in-/uitschakelen"
@@ -1900,6 +2145,9 @@ msgstr "Nieuw gebruikersgedefinieerd veld"
 
 msgid "New filter"
 msgstr "Nieuw filter"
+
+msgid "New label"
+msgstr "Nieuw label"
 
 msgid "New list"
 msgstr "Nieuwe lijst"
@@ -1946,9 +2194,6 @@ msgstr "Geen stemmingen"
 msgid "No results found"
 msgstr "Geen resultaten gevonden"
 
-msgid "No results found."
-msgstr "Geen resultaten gevonden."
-
 msgid "No review found"
 msgstr "Geen recensie gevonden"
 
@@ -1960,9 +2205,6 @@ msgstr "Geen nummers"
 
 msgid "No songs found"
 msgstr "Geen nummers gevonden"
-
-msgid "No sound menu found"
-msgstr "Geen geluidsmenu gevonden"
 
 msgid "No styles"
 msgstr "Geen stijlen"
@@ -2066,10 +2308,17 @@ msgstr ""
 "Uit: waarschijnlijker indien het label ingesteld is"
 
 msgid "Old name"
-msgstr "Vroegere naam:"
+msgstr "Oude naam"
 
 msgid "On top of other windows instead of below"
 msgstr "Op andere vensters plaatsen in plaats van eronder"
+
+msgid ""
+"One command is used per selected songs, unless $files is used, which is "
+"replaced by the list of selected files"
+msgstr ""
+"Er wordt één commando per geselecteerd nummer gebruikt, tenzij $files wordt "
+"gebruikt. Dat wordt dan vervangen door de lijst van geselecteerde bestanden"
 
 #, perl-brace-format
 msgid "One of these commands is required to play files of type {type} : {cmd}"
@@ -2082,9 +2331,6 @@ msgstr "Alleen mp3-bestanden die nog geen ID3v1-tag hebben aanpassen"
 
 msgid "Only show similar artists from local library"
 msgstr "Alleen gelijkaardige artiesten uit de aanwezige bibliotheek tonen"
-
-msgid "Only works when the review tab is displayed"
-msgstr "Werkt alleen wanneer de recensietab wordt getoond"
 
 msgid "Opacity"
 msgstr "Ondoorzichtigheid"
@@ -2119,9 +2365,6 @@ msgstr "Wachtrijvenster openen"
 msgid "Open Search window"
 msgstr "Zoekvenster openen"
 
-msgid "Open allmusic.com in your web browser"
-msgstr "Allmusic.com in uw browser openen"
-
 msgid "Open containing folder"
 msgstr "Bijbehorende map openen"
 
@@ -2131,11 +2374,11 @@ msgstr "Context- en wachtrijpaneel openen"
 msgid "Open context page"
 msgstr "Contextpagina openen"
 
+msgid "Open equalizer..."
+msgstr "Equalizer openen ..."
+
 msgid "Open existing list"
 msgstr "Bestaande lijst openen"
-
-msgid "Open files"
-msgstr "Bestanden openen"
 
 msgid "Open folder"
 msgstr "Map openen"
@@ -2195,6 +2438,9 @@ msgstr "Overlayopmaak:"
 msgid "Owner identifier"
 msgstr "Eigenaarsidentificatie"
 
+msgid "Paste link"
+msgstr "Plak link"
+
 msgid "Path,Album,Disc,Track,File"
 msgstr "Pad, Album, Schijf, Nummer, Bestand"
 
@@ -2207,8 +2453,20 @@ msgstr "Patroon om te zoeken naar .lrc-bestanden:"
 msgid "Pause"
 msgstr "Pauze"
 
+msgid "Per-song values"
+msgstr "Waarden per nummer"
+
+msgid "Persistent values"
+msgstr "Persistente waarden"
+
+msgid "Pick an existing one"
+msgstr "Kies een bestaande"
+
 msgid "Picture"
 msgstr "Afbeelding"
+
+msgid "Picture Browser"
+msgstr "Afbeeldingsbrowser"
 
 msgid "Picture Type"
 msgstr "Type afbeelding"
@@ -2226,6 +2484,9 @@ msgstr "Afbeeldingszoekerplugin"
 #, perl-format
 msgid "Picture size : %d"
 msgstr "Afbeeldingsgrootte: %d"
+
+msgid "Picture type"
+msgstr "Afbeeldingstype"
 
 msgid "Pictures and music files"
 msgstr "Afbeeldingen en muziekbestanden"
@@ -2263,6 +2524,9 @@ msgstr "Afspeelteller"
 msgid "Play filter"
 msgstr "Afspeelfilter"
 
+msgid "Play history"
+msgstr "Afspeelgeschiedenis"
+
 msgid "Play listed songs"
 msgstr "Nummers in de lijst afspelen"
 
@@ -2274,6 +2538,9 @@ msgstr "Afspelen/Pauze"
 
 msgid "Playback"
 msgstr "Afspelen"
+
+msgid "Playback ended unexpectedly."
+msgstr "Afspelen is onverwachts gestopt."
 
 msgid "Playcount: "
 msgstr "Aantal keer afgespeeld:"
@@ -2396,6 +2663,9 @@ msgstr "Aankoopprijs"
 msgid "Private Data"
 msgstr "Privédata"
 
+msgid "Proceed to next item."
+msgstr "Doorgaan naar volgende item."
+
 msgid "Produced (P)"
 msgstr "Geproduceerd (P)"
 
@@ -2409,7 +2679,7 @@ msgid "Provides context views using MozEmbed or WebKit"
 msgstr "Haalt bijbehorende info van het internet via MozEmbed of WebKit"
 
 msgid "Proxy host :"
-msgstr "Proxygastheer:"
+msgstr "Proxy-host:"
 
 msgid "Publication right"
 msgstr "Publicatierecht"
@@ -2457,6 +2727,9 @@ msgstr "Snel zoeken met bestandsboomweergave"
 msgid "Quit"
 msgstr "Afsluiten"
 
+msgid "Quit after this song"
+msgstr "Stoppen na dit nummer"
+
 msgid "Quit when queue empty"
 msgstr "Afsluiten zodra de wachtrij leeg is"
 
@@ -2486,6 +2759,9 @@ msgstr "Waardering tussen 0 en 100, of niets voor standaardwaardering"
 
 msgid "Rating range:"
 msgstr "Waarderingsbereik:"
+
+msgid "Raw filename with path"
+msgstr "Ruwe bestandsnaam met pad"
 
 msgid "Re-load layouts"
 msgstr "Lay-outs opnieuw inladen"
@@ -2524,17 +2800,11 @@ msgstr "Recent afgespeeld"
 msgid "Recently played songs"
 msgstr "Recent afgespeelde nummers"
 
-msgid "Record label"
-msgstr "Platenlabel"
-
 msgid "Recording Dates"
 msgstr "Data van opname"
 
 msgid "Recording date"
 msgstr "Datum van opname"
-
-msgid "Recording type"
-msgstr "Opnametype"
 
 msgid "Reference point :"
 msgstr "Referentiepunt:"
@@ -2597,6 +2867,9 @@ msgstr "Uit bibliotheek verwijderen"
 msgid "Remove from list"
 msgstr "Uit lijst verwijderen"
 
+msgid "Remove from persistent values"
+msgstr "Uit persistente waarden verwijderen"
+
 msgid "Remove from playlist"
 msgstr "Uit afspeellijst verwijderen"
 
@@ -2611,6 +2884,9 @@ msgstr "Label verwijderen"
 
 msgid "Remove list"
 msgstr "Lijst verwijderen"
+
+msgid "Remove picture"
+msgstr "Afbeelding verwijderen"
 
 msgid "Remove selected songs"
 msgstr "Geselecteerde nummers verwijderen"
@@ -2633,6 +2909,10 @@ msgstr "Deze widget verwijderen"
 msgid "Rename"
 msgstr "Hernoemen"
 
+#, perl-brace-format
+msgid "Rename '{label}'"
+msgstr "'{label}' hernoemen"
+
 msgid "Rename File"
 msgstr "Bestand hernoemen"
 
@@ -2645,11 +2925,17 @@ msgstr "Bestanden hernoemen volgens dit patroon:"
 msgid "Rename folder"
 msgstr "Map hernoemen"
 
+msgid "Rename label"
+msgstr "Label hernoemen"
+
 msgid "Rename this folder to :"
 msgstr "Deze map hernoemen in:"
 
 msgid "Rename/move files based on these fields :"
 msgstr "Bestanden hernoemen/verplaatsen op basis van deze velden:"
+
+msgid "Renaming failed"
+msgstr "Hernoemen mislukt"
 
 #, perl-brace-format
 msgid ""
@@ -2694,6 +2980,9 @@ msgstr "Collectie opnieuw inlezen"
 msgid "Reset filter"
 msgstr "Filter resetten"
 
+msgid "Reset zoom"
+msgstr "Zoom resetten"
+
 msgid "Retrieves album-relevant information (review etc.) from allmusic.com."
 msgstr "Haalt album-relevante informatie (zoals recensies) van allmusic.com."
 
@@ -2730,14 +3019,26 @@ msgstr "Ripplugin"
 msgid "Ripping software :"
 msgstr "Ripprogramma:"
 
+msgid "Row number"
+msgstr "Rijnummer"
+
 msgid "Run a command when playing a song"
 msgstr "Commando uitvoeren wanneer een nummer wordt afgespeeld"
 
 msgid "Run perl code"
 msgstr "Perl-code uitvoeren"
 
+msgid "Run shell command"
+msgstr "Shellcommando uitvoeren"
+
+msgid "Run shell command on selected songs"
+msgstr "Shellcommando uitvoeren op geselecteerde nummers"
+
 msgid "Run system command"
 msgstr "Systeemopdracht uitvoeren"
+
+msgid "Run system command on selected songs"
+msgstr "Systeemcommando uitvoeren op geselecteerde nummers"
 
 msgid "Running time"
 msgstr "Afspeeltijd"
@@ -2753,6 +3054,9 @@ msgstr "Zelfde artiest"
 
 msgid "Same title"
 msgstr "Zelfde titel"
+
+msgid "Same type as labels"
+msgstr "Zelfde type als labels"
 
 msgid "Same year"
 msgstr "Zelfde jaar"
@@ -2793,15 +3097,18 @@ msgstr "Nu opslaan"
 msgid "Save picture as"
 msgstr "Afbeelding opslaan als"
 
+msgid "Save preset"
+msgstr "Preset opslaan"
+
 msgid "Save review"
 msgstr "Recensie opslaan"
 
 msgid ""
 "Save selected fields for all tracks on the same album whenever album data is "
-"loaded from AMG or from file."
+"loaded from allmusic or from file."
 msgstr ""
-"Geselecteerde velden opslaan voor alle titels op dat album, zodra de "
-"albumdata geladen wordt vanuit AMG of vanuit een bestand."
+"Geselecteerde velden opslaan voor alle nummers op hetzelfde album, zodra de "
+"albumdata geladen worden vanaf allmusic of vanuit een bestand."
 
 #, perl-format
 msgid "Save tags/settings every %d minutes"
@@ -2839,6 +3146,9 @@ msgstr "Inlezen met gebruik van de albums, gedefinieerd in de tags"
 
 msgid "Scanning"
 msgstr "Inlezen"
+
+msgid "Scroll to zoom"
+msgstr "Scrollen om te zoomen"
 
 msgid "Scroll with song"
 msgstr "Nummer volgen"
@@ -2955,9 +3265,6 @@ msgstr "Huidige nummer selecteren"
 msgid "Select fields"
 msgstr "Velden selecteren"
 
-msgid "Select files"
-msgstr "Bestanden selecteren"
-
 msgid "Select matches"
 msgstr "Overeenkomsten selecteren"
 
@@ -2982,14 +3289,24 @@ msgstr "Verkoper"
 msgid "Send Title/Artist/Album in standard input"
 msgstr "Titel/artiest/album naar standaardinvoer doorsturen"
 
+msgid "Send now"
+msgstr "Nu verzenden"
+
 msgid "Set Current Song Rating"
 msgstr "Huidig nummer waarderen"
 
 msgid "Set Picture"
 msgstr "Afbeelding instellen"
 
+#, perl-brace-format
+msgid "Set as picture for '{name}'"
+msgstr "Als afbeelding gebruiken voor '{name}' "
+
 msgid "Set as primary filter"
 msgstr "Als primair filter instellen"
+
+msgid "Set equalizer"
+msgstr "Equalizer instellen"
 
 msgid "Set focus on a layout widget"
 msgstr "Focus op opmaakwidget instellen"
@@ -2999,6 +3316,12 @@ msgstr "Groepering instellen"
 
 msgid "Set icon"
 msgstr "Pictogram instellen"
+
+msgid "Set picture"
+msgstr "Afbeelding instellen"
+
+msgid "Set picture using this file"
+msgstr "Afbeelding instellen met dit bestand"
 
 msgid "Set player window layout"
 msgstr "Afspeelvensterlayout instellen"
@@ -3016,15 +3339,8 @@ msgstr "Instellingen"
 msgid "Settings on this page will only take effect after a restart"
 msgstr "De hier getoonde instellingen worden pas van kracht na een herstart"
 
-#, perl-format
-msgid ""
-"Shell command\n"
-"(some variables such as %f (current song filename) or %F (list of selected "
-"songs filenames) are available)"
-msgstr ""
-"Terminalopdracht\n"
-"(U kunt bepaalde variabelen, zoals %f (bestandsnaam van het huidige nummer) "
-"en %F (lijst van bestandsnamen van de geselecteerde nummers) gebruiken)"
+msgid "Shell command"
+msgstr "Shellcommando"
 
 #. Shift key
 msgctxt "Keyboard"
@@ -3043,6 +3359,12 @@ msgstr "Artiestpagina op Wikipedia tonen"
 msgid "Show album"
 msgstr "Album tonen"
 
+msgid "Show all files"
+msgstr "Alle bestanden tonen"
+
+msgid "Show artist picture"
+msgstr "Artiestafbeelding tonen"
+
 msgid "Show artist's biography"
 msgstr "Artiestbiografie tonen"
 
@@ -3052,17 +3374,32 @@ msgstr "Komende optredens van artiest tonen"
 msgid "Show buttons"
 msgstr "Knoppen tonen"
 
+msgid "Show embedded pictures"
+msgstr "Ingesloten afbeeldingen tonen"
+
+msgid "Show file list"
+msgstr "Bestandslijst tonen"
+
+msgid "Show file name extension"
+msgstr "Bestandsnaamextensie tonen"
+
+msgid "Show folder list"
+msgstr "Mappenlijst tonen"
+
 msgid "Show genre"
 msgstr "Genre tonen"
-
-msgid "Show in sound menu"
-msgstr "In geluidsmenu tonen"
 
 msgid "Show info panel"
 msgstr "Informatiepaneel tonen"
 
 msgid "Show main window"
 msgstr "Hoofdvenster tonen"
+
+msgid "Show more error details"
+msgstr "Meer foutdetails tonen"
+
+msgid "Show pdf pages"
+msgstr "PDF-pagina's tonen"
 
 msgid "Show playlist"
 msgstr "Afspeellijst tonen"
@@ -3084,6 +3421,9 @@ msgstr "Suggesties tonen"
 
 msgid "Show tabs"
 msgstr "Tabs tonen"
+
+msgid "Show toolbar"
+msgstr "Werkbalk tonen"
 
 msgid "Show tray icon"
 msgstr "Systeemvakpictogram tonen"
@@ -3115,6 +3455,12 @@ msgstr "Statusbalk tonen/verbergen"
 msgid "Shuffle"
 msgstr "Willekeurige volgorde"
 
+msgid "Shuffle list"
+msgstr "Lijst in willekeurige volgorde"
+
+msgid "Shuffle or re-shuffle the playlist"
+msgstr "Afspeellijst in (nieuwe) willekeurige volgorde"
+
 msgid "Shuffle queue"
 msgstr "Nummers in wachtrij in willekeurige volgorde plaatsen"
 
@@ -3142,11 +3488,23 @@ msgstr "Eenvoudige lijstweergave"
 msgid "Simple title"
 msgstr "Eenvoudige titel"
 
+msgid "Simplify tree"
+msgstr "Boom vereenvoudigen"
+
 msgid "Size"
 msgstr "Afmeting"
 
+msgid "Skip _All"
+msgstr "_Alles overslaan"
+
 msgid "Skip count"
 msgstr "Aantal keer overgeslagen"
+
+msgid "Skip history"
+msgstr "Geschiedenis overslaan"
+
+msgid "Skip this and any further errors."
+msgstr "Deze en toekomstige fouten overslaan."
 
 msgid "Skip to next song if an error occurs"
 msgstr "Naar het volgende nummer springen als er een fout optreedt"
@@ -3162,6 +3520,12 @@ msgstr "Kleine speler"
 
 msgid "Smaller browser"
 msgstr "Kleinere browser"
+
+#, perl-format
+msgid "Some variables such as %f (current song filename) are available"
+msgstr ""
+"U kunt bepaalde variabelen gebruiken, zoals %f (bestandsnaam van het huidige "
+"nummer)"
 
 msgid "Song"
 msgstr "Nummer"
@@ -3193,11 +3557,18 @@ msgstr "Sorteermodus aanpassen"
 msgid "Sort order"
 msgstr "Sorteervolgorde"
 
+#, perl-brace-format
+msgid "Source: {file}"
+msgstr "Bron: {file}"
+
 msgid "Split artist names on :"
 msgstr "Artiestnamen splitsen op:"
 
-msgid "Standard fields"
-msgstr "Standaardvelden"
+msgid "Star images"
+msgstr "Sterafbeeldingen"
+
+msgid "Start ReplayGain analysis"
+msgstr "ReplayGain-analyse starten"
 
 msgid "Start in tray"
 msgstr "In systeemvak opstarten"
@@ -3211,8 +3582,14 @@ msgstr "Statusbalk"
 msgid "Stop"
 msgstr "Stoppen"
 
+msgid "Stop after this song"
+msgstr "Stop na dit nummer"
+
 msgid "Stop checking"
 msgstr "Controle stoppen"
+
+msgid "Stop fetching albuminfo"
+msgstr "Ophalen van albuminfo stoppen"
 
 msgid "Stop scanning"
 msgstr "Inlezen stoppen"
@@ -3262,14 +3639,17 @@ msgstr "Zondag"
 msgid "Switch to fullscreen mode"
 msgstr "Naar volledig schermweergave overschakelen"
 
+msgid "Synchronize equalizer presets"
+msgstr "Synchroniseer equalizerpresets"
+
 msgid "System clock is not close enough to the current time"
 msgstr "Systeemklok wijkt te veel af van de huidige tijd"
 
+msgid "System command"
+msgstr "Systeem commando"
+
 msgid "System command :"
 msgstr "Systeemopdracht:"
-
-msgid "Tag"
-msgstr "Tag"
 
 msgid "Tags"
 msgstr "Tags"
@@ -3290,11 +3670,18 @@ msgstr ""
 msgid "The layout for this desktop widget is missing."
 msgstr "De opmaak voor deze bureaubladwidget ontbreekt."
 
+msgid "The save file seems incomplete, you may want to use a backup instead."
+msgstr "Het bestand lijkt onvolledig, probeer eens een back-up."
+
 msgid "Themes"
 msgstr "Thema's"
 
 msgid "These fields can be used :"
 msgstr "Deze velden kunnen worden gebruikt:"
+
+msgid "These values will always be in the list, even if they are not used"
+msgstr ""
+"Deze waarden zullen altijd in de lijst staan, ook als ze niet gebruikt worden"
 
 #, perl-brace-format
 msgid "This command is required to play files of type {type} : {cmd}"
@@ -3306,6 +3693,10 @@ msgid "This label is set for %d song."
 msgid_plural "This label is set for %d songs."
 msgstr[0] "Dit label is ingesteld voor %d nummer."
 msgstr[1] "Dit label is ingesteld voor %d nummers."
+
+msgid ""
+"This plugin is needed for gmusicbrowser to appear in unity's sound menu."
+msgstr "Deze plugin is nodig om gmusicbrowser is unity's geluidsmenu te tonen."
 
 msgid "This plugin requires :"
 msgstr "Pluginvereisten:"
@@ -3346,6 +3737,9 @@ msgstr "Titel en voortgang"
 msgid "Title - Artist - Album"
 msgstr "Titel - artiest - album"
 
+msgid "Title or filename"
+msgstr "Titel of bestandsnaam"
+
 #, perl-format
 msgid "Title: %t"
 msgstr "Titel: %t"
@@ -3374,6 +3768,9 @@ msgstr "Label toevoegen aan of verwijderen van het huidige nummer"
 
 msgid "Toggle between Random/Shuffle and Ordered"
 msgstr "Wisselen tussen geordend en willekeurig afspelen"
+
+msgid "Toggle edit mode"
+msgstr "Bewerken in- of uitschakelen"
 
 msgid "Toggle fullscreen mode"
 msgstr "Volledig schermweergave in- of uitschakelen"
@@ -3411,6 +3808,15 @@ msgstr "Dinsdag"
 msgid "Turn Off"
 msgstr "Uitschakelen"
 
+msgid "Turn equalizer off"
+msgstr "Equalizer uitschakelen"
+
+msgid "Turn equalizer on"
+msgstr "Equalizer inschakelen"
+
+msgid "Turn off computer after this song"
+msgstr "Computer afsluiten na dit nummer"
+
 msgid "Turn off computer when queue empty"
 msgstr "Computer afsluiten zodra de wachtrij leeg is"
 
@@ -3419,6 +3825,9 @@ msgstr "Adres"
 
 msgid "Unique file identifier"
 msgstr "Unieke bestandsidentificatie"
+
+msgid "Unknown"
+msgstr "Onbekend"
 
 msgid "Unknown album"
 msgstr "Onbekend album"
@@ -3557,6 +3966,12 @@ msgstr "Binary tonen"
 msgid "View binary data ..."
 msgstr "Binary-data tonen..."
 
+msgid "View in new window"
+msgstr "Openen in nieuw venster"
+
+msgid "View pictures from this album's folder"
+msgstr "Toon afbeeldingen uit de map van dit album"
+
 msgid "Volume : "
 msgstr "Volume:"
 
@@ -3609,7 +4024,7 @@ msgid ""
 "When changing songs, the previous song is added to the recent list even if "
 "not played at all."
 msgstr ""
-"Indien aangevinkt, zal het vorige nummer worden toegevoegd aan de lijst "
+"Indien aangevinkt zal het vorige nummer worden toegevoegd aan de lijst "
 "'Recent afgespeeld', ook indien het overgeslagen werd."
 
 msgid "When current song"
@@ -3639,6 +4054,9 @@ msgstr ""
 
 msgid "Will use default if not found"
 msgstr "Zal de standaardwaarde gebruiken indien niet gevonden"
+
+msgid "Will use system's default if blank"
+msgstr "Zal de systeemstandaard gebruiken indien leeg"
 
 #. Windows key
 msgctxt "Keyboard"
@@ -3677,12 +4095,28 @@ msgstr "Jaar - Artiest"
 msgid "Yes"
 msgstr "Ja"
 
+#, perl-brace-format
+msgid "You can find backups in {folder}"
+msgstr "U kan back-ups vinden in {folder}"
+
 msgid ""
 "You can force a check for these files by holding shift when selecting \"Re-"
 "read tags\""
 msgstr ""
 "U kunt een hercontrole van deze bestanden afdwingen door Shift ingedrukt te "
 "houden wanneer u 'Tags opnieuw inlezen' selecteert"
+
+#, perl-brace-format
+msgid ""
+"You can make custom stars by putting pictures in {folder}\n"
+"They must be named 'stars', optionally followed by a '-' and a word, "
+"followed by a number from 0 to 5 or 10\n"
+"Example: stars-custom0.png"
+msgstr ""
+"Je kan aangepaste sterren maken door afbeeldingen te plaatsen in {folder}\n"
+"Ze moeten 'stars' heten, eventueel gevolgd door een '-' en een woord, "
+"gevolgd door een nummer van 0 tot 5 of tot 10\n"
+"Voorbeeld: stars-aangepast0.png"
 
 msgid ""
 "You can use some markup, eg :\n"
@@ -3697,6 +4131,21 @@ msgstr ""
 msgid "You must specify a base folder"
 msgstr "U moet een map specifiëren."
 
+msgid "Zoom 1:1"
+msgstr "Ware grootte"
+
+msgid "Zoom in"
+msgstr "Zoom in"
+
+msgid "Zoom out"
+msgstr "Zoom out"
+
+msgid "Zoom to fit"
+msgstr "Passend"
+
+msgid "_Cancel"
+msgstr "_Annuleren"
+
 msgid "_Insert column"
 msgstr "_Kolom invoeren"
 
@@ -3706,11 +4155,17 @@ msgstr "_Deze kolom verwijderen"
 msgid "_Retry"
 msgstr "_Opnieuw proberen"
 
+msgid "_Skip"
+msgstr "_Overslaan"
+
 msgid "_Sort by"
 msgstr "_Sorteren op"
 
 msgid "a bright coloured fish"
 msgstr "een felgekleurde vis"
+
+msgid "abort"
+msgstr "afbreken"
 
 msgid "abort copy"
 msgstr "kopiëren annuleren"
@@ -3736,14 +4191,14 @@ msgctxt "Field_aliases"
 msgid "album,on"
 msgstr "album, op"
 
+msgid "albums missing reviews"
+msgstr "albums zonder reviews"
+
 msgid "alphabetical"
 msgstr "alfabetisch"
 
 msgid "amixer control :"
 msgstr "amixerbediening:"
-
-msgid "another example"
-msgstr "ander voorbeeld"
 
 msgid "applied on reload"
 msgstr "toegepast bij de volgende herstart"
@@ -3874,7 +4329,7 @@ msgid "composer"
 msgstr "componist"
 
 msgid "conductor"
-msgstr "documenteerder"
+msgstr "dirigent"
 
 msgid "connection failed"
 msgstr "verbinden mislukt"
@@ -3891,7 +4346,7 @@ msgstr "bevat %s"
 
 #, perl-format
 msgid "contains %s (case sensitive)"
-msgstr "bevat %s (hoofdletterongevoelig)"
+msgstr "bevat %s (hoofdlettergevoelig)"
 
 msgid "counter"
 msgstr "afspeelteller"
@@ -3975,6 +4430,9 @@ msgstr "leeg"
 msgid "enable gapless (experimental)"
 msgstr "zonder pauzes afspelen (experimenteel)"
 
+msgid "entire collection"
+msgstr "volledige collectie"
+
 msgid "error"
 msgstr "fout"
 
@@ -3984,6 +4442,9 @@ msgstr "bijvoorbeeld:"
 #, perl-brace-format
 msgid "example (selected song) : {score}  ({chances})"
 msgstr "bijvoorbeeld (geselecteerd nummer): {score} ({chances})"
+
+msgid "example :"
+msgstr "voorbeeld:"
 
 msgid "example : "
 msgstr "voorbeeld:"
@@ -4005,8 +4466,15 @@ msgstr "onwaar"
 msgid "favorite"
 msgstr "favoriete"
 
+msgid "file $current/$end"
+msgstr "bestand $current/$end"
+
 msgid "file tag"
 msgstr "bestandstag"
+
+#, perl-brace-format
+msgid "file: {filename}"
+msgstr "bestand: {filename}"
 
 msgid "filters"
 msgstr "filters"
@@ -4025,6 +4493,9 @@ msgstr "voor bestanden zonder VBR-koptekst"
 
 msgid "front cover"
 msgstr "voorzijde albumhoes"
+
+msgid "fuzzy match"
+msgstr "fuzzy match"
 
 msgid "gmusicbrowser"
 msgstr "gmusicbrowser"
@@ -4080,6 +4551,10 @@ msgstr "afbeelding"
 
 msgid "imported list"
 msgstr "geïmporteerde lijst"
+
+#, perl-format
+msgid "in %d/%d files"
+msgstr "in %d/%d bestanden"
 
 #, perl-format
 msgid "in %l"
@@ -4138,8 +4613,11 @@ msgstr "is 44,1 kHz"
 msgid "is a flac file"
 msgstr "is een flac-bestand"
 
-msgid "is a m4a file"
-msgstr "is een m4a-bestand"
+msgid "is a lossless file"
+msgstr "is een bestand in een formaat zonder kwaliteitsverlies"
+
+msgid "is a lossy file"
+msgstr "is een bestand in een formaat met kwaliteitsverlies"
 
 msgid "is a mp3 file"
 msgstr "is een mp3-bestand"
@@ -4147,14 +4625,26 @@ msgstr "is een mp3-bestand"
 msgid "is a musepack file"
 msgstr "is een musepackbestand"
 
+msgid "is a vorbis file"
+msgstr "is een vorbis-bestand"
+
 msgid "is a wavepack file"
 msgstr "is een wavepackbestand"
+
+msgid "is an aac file"
+msgstr "is een aac-bestand"
+
+msgid "is an alac file"
+msgstr "is een alac-bestand"
 
 msgid "is an ape file"
 msgstr "is een ape-bestand"
 
-msgid "is an ogg file"
-msgstr "is een ogg-bestand"
+msgid "is an mp4/m4a file"
+msgstr "is een mp4/m4a-bestand"
+
+msgid "is defined"
+msgstr "is gedefinieerd"
 
 msgid "is equal to"
 msgstr "is gelijk aan"
@@ -4175,6 +4665,9 @@ msgstr "is in %s"
 
 msgid "is mono"
 msgstr "is mono"
+
+msgid "is not defined"
+msgstr "is niet gedefinieerd"
 
 msgid "is smart equal"
 msgstr "is gelijk aan (slimme modus)"
@@ -4306,9 +4799,6 @@ msgstr "meer dan %s geleden "
 msgid "mosaic mode"
 msgstr "mozaïekweergave"
 
-msgid "move folder"
-msgstr "map verplaatsen"
-
 msgid "movie/video screen capture"
 msgstr "video-opname"
 
@@ -4320,10 +4810,13 @@ msgstr ""
 "lengte en bitrate te bepalen"
 
 msgid "mplayer executable :"
-msgstr "mplayeropdracht:"
+msgstr "uitvoerbaar bestand van mplayer:"
 
 msgid "mplayer options :"
-msgstr "mplayeropties:"
+msgstr "opties voor mplayer:"
+
+msgid "mpv options :"
+msgstr "mpv-opties:"
 
 msgid "multi-lines string"
 msgstr "tekenreeks met meerdere regels"
@@ -4345,6 +4838,10 @@ msgstr "nooit"
 
 msgid "never played"
 msgstr "nooit afgespeeld"
+
+#, perl-format
+msgid "no %s fuzzy match with %s"
+msgstr "geen %s fuzzy match met %s"
 
 msgid "no matches found, you might want to remove some search terms."
 msgstr ""
@@ -4374,8 +4871,19 @@ msgstr "nee op alles"
 msgid "noname"
 msgstr "zonder naam"
 
+msgid "none"
+msgstr "geen"
+
 msgid "normal"
 msgstr "normaal"
+
+#, perl-format
+msgid "not after %s"
+msgstr "niet na %s"
+
+#, perl-format
+msgid "not before %s"
+msgstr "niet voor %s"
 
 #, perl-format
 msgid "not between %s ago and %s ago"
@@ -4388,6 +4896,9 @@ msgstr "niet tussen %s en %s"
 msgid "not bootleg"
 msgstr "niet een bootleg"
 
+msgid "not defined"
+msgstr "niet gedefinieerd"
+
 #, perl-format
 msgid "not in the bottom %s"
 msgstr "niet in de onderste %s"
@@ -4395,6 +4906,14 @@ msgstr "niet in de onderste %s"
 #, perl-format
 msgid "not in the top %s"
 msgstr "niet in de bovenste %s"
+
+#, perl-format
+msgid "not less than %s ago"
+msgstr "niet minder dan %s geleden"
+
+#, perl-format
+msgid "not more than %s ago"
+msgstr "niet meer dan %s geleden "
 
 #, perl-format
 msgid "not present in %s"
@@ -4448,6 +4967,14 @@ msgstr "ander pictogram"
 msgid "output device :"
 msgstr "uitvoerapparaat:"
 
+#, perl-format
+msgid "page %d"
+msgstr "pagina %d"
+
+#, perl-brace-format
+msgid "page {number}"
+msgstr "pagina {number}"
+
 msgid "password :"
 msgstr "wachtwoord:"
 
@@ -4472,6 +4999,13 @@ msgstr "voorversterking"
 #, perl-format
 msgid "pre-amp : %d dB"
 msgstr "voorversterking: %d dB"
+
+msgid ""
+"pre-set name or 10 numbers between 12 and -12 (-24 for gstreamer) separated "
+"by ':', or 0 (for off), or 1 (for on)"
+msgstr ""
+"vooringestelde naam of 10 getallen tussen 12 en -12 (-24 voor gstreamer) "
+"gescheiden door ':', of 0 (uit) of 1 (aan)"
 
 #, perl-format
 msgid "present in %s"
@@ -4558,6 +5092,9 @@ msgstr "instellen op"
 #, perl-format
 msgid "set to %s"
 msgstr "instellen op %s"
+
+msgid "show histogram background"
+msgstr "toon histogram-achtergrond"
 
 msgid "show pictures"
 msgstr "afbeeldingen tonen"
@@ -4705,6 +5242,12 @@ msgstr "weken"
 msgid "weight :"
 msgstr "gewicht:"
 
+msgid "when file changes"
+msgstr "wanneer bestand verandert"
+
+msgid "when folder changes"
+msgstr "wanneer map verandert"
+
 msgid "wikipedia, lyrics, and custom webpages"
 msgstr "Wikipedia, sonteksten en gebruikersgedefinieerde websites"
 
@@ -4778,24 +5321,24 @@ msgid "{folder} already exists"
 msgstr "{folder} bestaat al"
 
 #, perl-brace-format
-msgid "{hours} hours {min} min {sec} s ({size} M)"
-msgstr "{hours} uur {min} min {sec} s ({size} MB)"
+msgid "{hours} hours {min} min {sec} s"
+msgstr "{hours} uur {min} min {sec} s"
 
 #, perl-brace-format
-msgid "{hours}h {min}m {sec}s ({size}M)"
-msgstr "{hours}u {min}m {sec}s ({size}MB)"
+msgid "{hours}h {min}m {sec}s"
+msgstr "{hours}u {min}m {sec}s"
 
 #, perl-brace-format
 msgid "{hours}h{min}m{sec}s"
 msgstr "{hours}u{min}m{sec}s"
 
 #, perl-brace-format
-msgid "{min} min {sec} s ({size} M)"
-msgstr "{min} min {sec} s ({size} MB)"
+msgid "{min} min {sec} s"
+msgstr "{min}min {sec}s"
 
 #, perl-brace-format
-msgid "{min}m {sec}s ({size}M)"
-msgstr "{min}m {sec}s ({size}MB)"
+msgid "{min}m {sec}s"
+msgstr "{min}m {sec}s"
 
 #, perl-brace-format
 msgid "{min}m{sec}s"
@@ -4815,3 +5358,80 @@ msgstr "{song} door {artist}"
 
 msgid "|-separated list of widget names"
 msgstr "widgetnaamlijst, items gescheiden door |"
+
+#~ msgid "# songs"
+#~ msgstr "# nummers"
+
+#~ msgid "%d Song"
+#~ msgid_plural "%d Songs"
+#~ msgstr[0] "%d nummer"
+#~ msgstr[1] "%d nummers"
+
+#~ msgid "(applied after restart)"
+#~ msgstr "(vereist een herstart)"
+
+#~ msgid "Abort all"
+#~ msgstr "Breek alles af"
+
+#~ msgid "Add label"
+#~ msgstr "Label toevoegen"
+
+#~ msgid "Add to playlist"
+#~ msgstr "Aan afspeellijst toevoegen"
+
+#~ msgid "Custom fields"
+#~ msgstr "Gebruikergedefinieerde velden"
+
+#~ msgid "Do not add songs that can't be played"
+#~ msgstr "Geen nummers toevoegen die niet afgespeeld kunnen worden"
+
+#~ msgid "Field name"
+#~ msgstr "Veldnaam"
+
+#~ msgid "Hide Artist/Album bar"
+#~ msgstr "Verberg artiest-/albumpaneel"
+
+#~ msgid "No results found."
+#~ msgstr "Geen resultaten gevonden."
+
+#~ msgid "No sound menu found"
+#~ msgstr "Geen geluidsmenu gevonden"
+
+#~ msgid "Only works when the review tab is displayed"
+#~ msgstr "Werkt alleen wanneer de recensietab wordt getoond"
+
+#~ msgid "Open allmusic.com in your web browser"
+#~ msgstr "Allmusic.com in uw browser openen"
+
+#~ msgid "Open files"
+#~ msgstr "Bestanden openen"
+
+#~ msgid "Record label"
+#~ msgstr "Platenlabel"
+
+#~ msgid "Recording type"
+#~ msgstr "Opnametype"
+
+#~ msgid "Show in sound menu"
+#~ msgstr "In geluidsmenu tonen"
+
+#~ msgid "Standard fields"
+#~ msgstr "Standaardvelden"
+
+#~ msgid "Tag"
+#~ msgstr "Tag"
+
+#~ msgid "another example"
+#~ msgstr "ander voorbeeld"
+
+#~ msgid "move folder"
+#~ msgstr "map verplaatsen"
+
+#~ msgid "{hours}h {min}m {sec}s ({size}M)"
+#~ msgstr "{hours}u {min}m {sec}s ({size}MB)"
+
+#~ msgid "{min} min {sec} s ({size} M)"
+#~ msgstr "{min} min {sec} s ({size} MB)"
+
+#~ msgid "{min}m {sec}s ({size}M)"
+#~ msgstr "{min}m {sec}s ({size}MB)"

--- a/po/nl.po
+++ b/po/nl.po
@@ -6,7 +6,7 @@ msgstr ""
 "Project-Id-Version: gmusicbrowser 1.1008\n"
 "Report-Msgid-Bugs-To: squentin@free.fr\n"
 "POT-Creation-Date: 2015-12-29 15:39+0100\n"
-"PO-Revision-Date: 2015-12-29 16:07+0100\n"
+"PO-Revision-Date: 2015-12-29 16:30+0100\n"
 "Last-Translator: Midgard <@M1dgard on GitHub>\n"
 "Language-Team: Nederlands <@M1dgard on GitHub>\n"
 "Language: nl\n"
@@ -342,7 +342,7 @@ msgid ""
 " dates more recent than number1 seconds will use format1, ..."
 msgstr ""
 "Eventueel kan de volgende opmaak gebruikt worden:\n"
-" standaard getal1 opmaak1 getal2 opmaak2...\n"
+" standaard getal1 opmaak1 getal2 opmaak2 ...\n"
 " gegevens recenter dan getal1 seconden zullen opmaak1 gebruiken, ..."
 
 msgid ""
@@ -605,13 +605,13 @@ msgid "Auto"
 msgstr "Automatisch"
 
 msgid "Auto fill based on filenames ..."
-msgstr "Automatisch invullen op basis van bestandsnamen..."
+msgstr "Automatisch invullen op basis van bestandsnamen ..."
 
 msgid "Auto fill only blank fields"
 msgstr "Enkel lege velden automatisch invullen"
 
 msgid "Auto fill up to"
-msgstr "Automatisch invullen "
+msgstr "Aantal nummers om automatisch aan te vullen"
 
 msgid "Auto filter"
 msgstr "Auto-filter"
@@ -835,7 +835,7 @@ msgid "Choose font for lyrics"
 msgstr "Kies een lettertype voor de songtekst"
 
 msgid "Choose font..."
-msgstr "Kies een lettertype..."
+msgstr "Kies een lettertype ..."
 
 #, perl-brace-format
 msgid "Choose icon for label {name}"
@@ -1212,7 +1212,7 @@ msgid "Edit Settings"
 msgstr "Instellingen bewerken"
 
 msgid "Edit auto-fill formats ..."
-msgstr "Automatisch-opvullen-opmaak bewerken..."
+msgstr "Automatisch-opvullen-opmaak bewerken ..."
 
 msgid "Edit filter"
 msgstr "Filter bewerken"
@@ -1942,7 +1942,7 @@ msgid "Loading failed."
 msgstr "Laden mislukt."
 
 msgid "Loading..."
-msgstr "Laden..."
+msgstr "Laden ..."
 
 msgid "Lock"
 msgstr "Vergrendel"
@@ -2354,6 +2354,9 @@ msgstr "Alleen mp3-bestanden die nog geen ID3v1-tag hebben aanpassen"
 msgid "Only show similar artists from local library"
 msgstr "Alleen gelijkaardige artiesten uit de aanwezige bibliotheek tonen"
 
+msgid "Only whole levels"
+msgstr "Enkel volledige niveaus"
+
 msgid "Opacity"
 msgstr "Ondoorzichtigheid"
 
@@ -2556,6 +2559,9 @@ msgstr "Nummers in de lijst afspelen"
 msgid "Play order"
 msgstr "Afspeelvolgorde"
 
+msgid "Play, queue or track"
+msgstr "Afspelen, wachtrij of tracknummer"
+
 msgid "Play/Pause"
 msgstr "Afspelen/Pauze"
 
@@ -2754,7 +2760,7 @@ msgid "Quit"
 msgstr "Afsluiten"
 
 msgid "Quit after this song"
-msgstr "Stoppen na dit nummer"
+msgstr "Gmusicbrowser afsluiten na dit nummer"
 
 msgid "Quit when queue empty"
 msgstr "Afsluiten zodra de wachtrij leeg is"
@@ -2824,7 +2830,7 @@ msgid "Recently played"
 msgstr "Recent afgespeeld"
 
 msgid "Recently played songs"
-msgstr "Recent afgespeelde nummers"
+msgstr "Laatst afgespeeld nummer"
 
 msgid "Recording Dates"
 msgstr "Data van opname"
@@ -2986,7 +2992,7 @@ msgid "Replace existing values"
 msgstr "Bestaande waarden vervangen"
 
 msgid "Replace..."
-msgstr "Vervangen..."
+msgstr "Vervangen ..."
 
 msgid "ReplayGain options"
 msgstr "ReplayGain-opties"
@@ -3109,7 +3115,7 @@ msgid "Save artist biography"
 msgstr "Artiestbiografie opslaan"
 
 msgid "Save as..."
-msgstr "Opslaan als..."
+msgstr "Opslaan als ..."
 
 msgid "Save current filter as"
 msgstr "Huidig filter opslaan als"
@@ -3898,7 +3904,7 @@ msgid "Update tags"
 msgstr "Tags updaten"
 
 msgid "Update tags..."
-msgstr "Tags updaten..."
+msgstr "Tags updaten ..."
 
 msgid "Upper left"
 msgstr "Linksboven"
@@ -3997,10 +4003,10 @@ msgid "View"
 msgstr "Tonen"
 
 msgid "View Binary"
-msgstr "Binary tonen"
+msgstr "Binair tonen"
 
 msgid "View binary data ..."
-msgstr "Binary-data tonen..."
+msgstr "Binaire data tonen ..."
 
 msgid "View in new window"
 msgstr "Openen in nieuw venster"
@@ -4106,7 +4112,7 @@ msgid "Words that begin with"
 msgstr "Woorden die starten met"
 
 msgid "Write filenames to ..."
-msgstr "Bestandsnamen schrijven naar..."
+msgstr "Bestandsnamen schrijven naar ..."
 
 msgid ""
 "Write value of selected fields in the tags. Useful for fields that were "

--- a/po/nl.po
+++ b/po/nl.po
@@ -6,9 +6,9 @@ msgstr ""
 "Project-Id-Version: gmusicbrowser 1.1008\n"
 "Report-Msgid-Bugs-To: squentin@free.fr\n"
 "POT-Creation-Date: 2015-12-28 17:38+0100\n"
-"PO-Revision-Date: 2015-12-28 22:26+0100\n"
-"Last-Translator: M1dgard\n"
-"Language-Team: Nederlands <gijs.timmers@student.kuleuven.be>\n"
+"PO-Revision-Date: 2015-12-28 23:43+0100\n"
+"Last-Translator: Midgard <@M1dgard on GitHub>\n"
+"Language-Team: Nederlands <@M1dgard on GitHub>\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -480,7 +480,7 @@ msgstr ""
 "toevoegen aan de lijst van 'Genres'."
 
 msgid "Allow for scheduling fade-out and stop"
-msgstr "Geplande fade-out en stoppen toestaan."
+msgstr "Geplande fade-out en stoppen mogelijk maken"
 
 msgid "Allows controlling gmusicbrowser via DBus using the MPRIS v1.0 standard"
 msgstr ""
@@ -705,7 +705,10 @@ msgid "Can be relative by using + or -"
 msgstr "Kan worden aangepast met + en -"
 
 msgid "Can be searched with :"
-msgstr "Kan doorzocht worden met:"
+msgstr "Kan worden gevonden met deze trefwoorden:"
+
+msgid "Can be used as a variable with :"
+msgstr "Kan als variabele worden gebruikt met:"
 
 msgid "Can't change the volume in non-gstreamer iceserver mode"
 msgstr "Kan het volume niet veranderen in non-gstreamer-iceservermodus."
@@ -885,7 +888,7 @@ msgid "Collection"
 msgstr "Verzameling"
 
 msgid "Command"
-msgstr "Commando"
+msgstr "Actie"
 
 msgid "Command to launch when the button is pressed"
 msgstr "Uit te voeren commando wanneer de knop wordt ingedrukt"
@@ -999,7 +1002,7 @@ msgid "Current song must always be in the playlist"
 msgstr "Huidig nummer moet altijd in de afspeellijst staan"
 
 msgid "Custom"
-msgstr "Gebruikergedefinieerd"
+msgstr "Aangepast"
 
 msgid "Custom Text"
 msgstr "Persoonlijke tekst"
@@ -1008,7 +1011,7 @@ msgid "Custom URL"
 msgstr "Persoonlijke URL"
 
 msgid "Custom command :"
-msgstr "Gebruikergedefinieerde opdracht:"
+msgstr "Aangepast commando:"
 
 msgid "Custom context pages :"
 msgstr "Gebruikergedefinieerde contextpanelen:"
@@ -1454,7 +1457,7 @@ msgstr "Fade-out"
 
 #, perl-format
 msgid "Fade-out in %d seconds"
-msgstr "Fade-out binnen %d seconden"
+msgstr "Fade-out gedurende %d seconden"
 
 msgid "Fade-out then stop"
 msgstr "Fade-out, daarna stoppen"
@@ -1570,7 +1573,7 @@ msgid "Folders to search for new songs"
 msgstr "Mappen om in te zoeken naar nieuwe nummers:"
 
 msgid "Follow playing song"
-msgstr "Afgespeeld nummer volgen"
+msgstr "Nummer volgen tijdens afspelen"
 
 msgid "Follow selected song"
 msgstr "Geselecteerd nummer volgen"
@@ -1690,6 +1693,14 @@ msgstr "Pictogramthema:"
 
 msgid "Identifier in file tag"
 msgstr "Identificatie in bestandstag"
+
+msgid ""
+"If checked, the shortcut has higher priority than the default shortcut of "
+"widgets. Warning: this can make some features inaccessible"
+msgstr ""
+"Indien aangevinkt heeft de sneltoets een hogere prioriteit dan de "
+"standaardsneltoets van je computer. Waarschuwing: dit kan bepaalde functies "
+"ontoegankelijk maken"
 
 msgid ""
 "If one of these words is at the start of the string, it will be ignored when "
@@ -2634,7 +2645,7 @@ msgid "Pre-set"
 msgstr "Vooraf ingesteld"
 
 msgid "Prefered place to load and save lyrics :"
-msgstr "Lokatie om songteksten te laden en op te slaan:"
+msgstr "Voorkeurslocatie om songteksten te laden en op te slaan:"
 
 msgid "Preferences"
 msgstr "Voorkeuren"
@@ -2977,6 +2988,9 @@ msgstr "Opnieuw inlezen"
 msgid "Rescan Collection"
 msgstr "Collectie opnieuw inlezen"
 
+msgid "Reset current value if no tag found in file"
+msgstr "Huidige "
+
 msgid "Reset filter"
 msgstr "Filter resetten"
 
@@ -3139,10 +3153,10 @@ msgid "Scan per-file track gain"
 msgstr "Volumeversterking per bestand bepalen"
 
 msgid "Scan this file"
-msgstr "Dit bestand inlezen"
+msgstr "Dit bestand analyseren"
 
 msgid "Scan using tag-defined album"
-msgstr "Inlezen met gebruik van de albums, gedefinieerd in de tags"
+msgstr "Analyseren aan de hand van album"
 
 msgid "Scanning"
 msgstr "Inlezen"
@@ -3298,6 +3312,9 @@ msgstr "Huidig nummer waarderen"
 msgid "Set Picture"
 msgstr "Afbeelding instellen"
 
+msgid "Set action when song ends"
+msgstr "Actie instellen wanneer nummer eindigt"
+
 #, perl-brace-format
 msgid "Set as picture for '{name}'"
 msgstr "Als afbeelding gebruiken voor '{name}' "
@@ -3373,6 +3390,9 @@ msgstr "Komende optredens van artiest tonen"
 
 msgid "Show buttons"
 msgstr "Knoppen tonen"
+
+msgid "Show edition submenu in song context menu"
+msgstr "Toon submenu om veld te bewerken in contextmenu van nummer"
 
 msgid "Show embedded pictures"
 msgstr "Ingesloten afbeeldingen tonen"
@@ -3492,7 +3512,7 @@ msgid "Simplify tree"
 msgstr "Boom vereenvoudigen"
 
 msgid "Size"
-msgstr "Afmeting"
+msgstr "Grootte"
 
 msgid "Skip _All"
 msgstr "_Alles overslaan"
@@ -4147,7 +4167,7 @@ msgid "_Cancel"
 msgstr "_Annuleren"
 
 msgid "_Insert column"
-msgstr "_Kolom invoeren"
+msgstr "_Kolom invoegen"
 
 msgid "_Remove this column"
 msgstr "_Deze kolom verwijderen"
@@ -4185,6 +4205,9 @@ msgstr "na"
 #, perl-format
 msgid "after %s"
 msgstr "na %s"
+
+msgid "album information now for"
+msgstr "albuminformatie nu voor"
 
 #. comma-separated list of field aliases for album, these are in addition to english aliases
 msgctxt "Field_aliases"
@@ -5249,7 +5272,7 @@ msgid "when folder changes"
 msgstr "wanneer map verandert"
 
 msgid "wikipedia, lyrics, and custom webpages"
-msgstr "Wikipedia, sonteksten en gebruikersgedefinieerde websites"
+msgstr "Wikipedia, songteksten en gebruikersgedefinieerde websites"
 
 msgid "with browser"
 msgstr "met browser"


### PR DESCRIPTION
I started working on this after I recommended gmusicbrowser to someone with a computer set to Dutch. They told me that the texts were not really clear.

This pull request improves the Dutch translation, fixing some grammar and spelling mistakes, and changing some terminology. Both the person to whom I had recommended gmusicbrowser and I have tested this and it's at least a bit better.
