### PR TITLE
Added extra keyword   ft   ft.   into Artists_split and  Artists_from_title

### DIFF
--- a/gmusicbrowser.pl
+++ b/gmusicbrowser.pl
@@ -664,12 +664,14 @@ our %Artists_split=
 	',?\s+and\s+'		=> "and",	#case-sensitive because the user might want to use "And" in artist names that should NOT be splitted
 	',?\s+And\s+'		=> "And",
 	'\s+featuring\s+'	=> "featuring",
-	'\s+feat\.\s+'		=> "feat.",
+	'\s+feat\.*\s+'		=> "feat", # feat and feat.
+	'\s+ft\.*\s+'		=> "ft",   # ft and ft.
 	'\s+[Vv][Ss]\s+'	=> "VS",
 );
 our %Artists_from_title=
 (	'\(with\s+([^)]+)\)'		=> "(with X)",
-	'\(feat\.\s+([^)]+)\)'		=> "(feat. X)",
+	'\(ft\.*\s+([^)]+)\)'		=> "(ft X)",   # ft and ft.
+	'\(feat\.*\s+([^)]+)\)'		=> "(feat X)", # feat and feat.
 	'\(featuring\s+([^)]+)\)'	=> "(featuring X)",
 );
 


### PR DESCRIPTION
I found out my music collection has  sometimes "ft" keyword in the title tags and file names. 
The "ft" keyword was missing inside gmb so I add it and also little changed/simplified the existing regex to match both ft & ft. feat & feat. 