### PR TITLE
Support for opus format

### DIFF
--- a/gmusicbrowser.pl
+++ b/gmusicbrowser.pl
@@ -233,7 +233,7 @@ sub barename #filename without extension
 
 our %Alias_ext;	#define alternate file extensions (ie: .ogg files treated as .oga files)
 INIT {%Alias_ext=(mp2=>'mp3', ogg=> 'oga', m4b=>'m4a');} #needs to be in a INIT block because used in a INIT block in gmusicbrowser_tags.pm
-our @ScanExt= qw/mp3 mp2 ogg oga flac mpc ape wv m4a m4b/;
+our @ScanExt= qw/mp3 mp2 ogg oga opus flac mpc ape wv m4a m4b/;
 
 our ($Verbose,$debug);
 our %CmdLine;

--- a/gmusicbrowser_gstreamer-1.x.pm
+++ b/gmusicbrowser_gstreamer-1.x.pm
@@ -41,6 +41,7 @@ BEGIN
 		oga => 'vorbisdec',			flac=> 'flacdec',
 		ape => 'avdec_ape ffdec_ape',		wv  => 'wavpackdec',
 		mpc => 'musepackdec avdec_mpc8',	m4a => 'faad',
+		opus => 'opusdec',
   );
 
   my $reg= GStreamer1::Registry::get();

--- a/gmusicbrowser_mplayer.pm
+++ b/gmusicbrowser_mplayer.pm
@@ -48,6 +48,7 @@ sub supported_formats
 		elsif	(m/^ffwavpack.*working/){$supported{wv}=undef}
 		elsif	(m/^ffape.*working/)	{$supported{ape}=undef}
 		elsif	(m/^faad.*working/)	{$supported{m4a}=undef}
+		elsif	(m/^ffopus.*working/)	{$supported{opus}=undef}
 	 }
 	}
 	return keys %supported;

--- a/gmusicbrowser_mpv.pm
+++ b/gmusicbrowser_mpv.pm
@@ -65,6 +65,7 @@ sub supported_formats
 		elsif	(m/:wavpack\s/) {$supported{wv}=undef}
 		elsif	(m/:ape\s/)	{$supported{ape}=undef}
 		elsif	(m/:aac\s/)	{$supported{m4a}=undef}
+		elsif	(m/:opus\s/)	{$supported{opus}=undef}
 	 }
 	}
 	return keys %supported;

--- a/gmusicbrowser_tags.pm
+++ b/gmusicbrowser_tags.pm
@@ -32,6 +32,7 @@ INIT
 	ape	=> ['Tag::APEfile',	'ape v{version}',		'APE ID3v2 lyrics3v2 ID3v1',],
 	wv	=> ['Tag::WVfile',	'wv v{version}',		'APE ID3v1',],
 	m4a	=> ['Tag::M4A',		'mp4 {traktype}',		'ilst',],
+	opus	=> ['Tag::OGG',		'opus v{version}',		'opus',],
 );
  $FORMATS{$_}=$FORMATS{ $::Alias_ext{$_} } for keys %::Alias_ext;
 }


### PR DESCRIPTION
Add support for opus files, i.e. ogg container/opus codec. Actually playing them only works with Gstreamer 1.x, mpv, and mplayer backends.