### PR TITLE
Use lyrics data type for M4A and Lyrics3v2

### DIFF
--- a/gmusicbrowser_tags.pm
+++ b/gmusicbrowser_tags.pm
@@ -1882,7 +1882,7 @@ INIT
 	fmps_lyrics	=> [_"Lyrics",14,'L'],
   };
   my $lyrics3v2_types=
-  {	LYR => [_"Lyrics",7,'M'],
+  {	LYR => [_"Lyrics",7,'L'],
 	INF => [_"Info",6,'M'],
 	AUT => [_"Author",5],
 	EAL => [_"Album",4],
@@ -1897,7 +1897,7 @@ INIT
 	"\xA9cmt" => [_"Comment",12,'M'],
 	"\xA9gen" => [_"Genre",10],
 	"\xA9wrt" => [_"Author",14],
-	"\xA9lyr" => [_"Lyrics",50],
+	"\xA9lyr" => [_"Lyrics",50,'L'],
 	"\xA9too" => [_"Encoder",51],
 	'----'	  => [_"Custom",52,'ttt'],
 	trkn	  => [_"Track",6],


### PR DESCRIPTION
This makes the lyrics field easier to edit, by using the large separate lyric editor rather than an inline text box.

Many thanks for this great program, by the way!