### PR TITLE
Add StartupWMClass

### DIFF
--- a/gmusicbrowser.desktop
+++ b/gmusicbrowser.desktop
@@ -6,6 +6,7 @@ Type=Application
 Icon=gmusicbrowser
 Categories=Audio;AudioVideo;
 StartupNotify=true
+StartupWMClass=gmusicbrowser
 Comment[fr]=Jukebox pour de grandes collections de mp3/ogg/flac/mpc
 #MimeType=audio/x-musepack;application/x-musepack;audio/musepack;application/musepack;audio/mpc;audio/x-mpc;audio/x-mp3;audio/mpeg;audio/x-mpeg;audio/x-mpeg-3;audio/mpeg3;application/ogg;application/x-ogg;audio/vorbis;audio/x-vorbis;audio/ogg;audio/x-ogg;audio/x-flac;application/x-flac;audio/flac;
 


### PR DESCRIPTION
This allows application launchers and docks like plank or docky to match open windows to the desktop file/launcher icon