### PR TITLE
Fix the warning: Use of uninitialized value $thousandsep in substitut…

### DIFF
--- a/gmusicbrowser.pl
+++ b/gmusicbrowser.pl
@@ -5121,7 +5121,9 @@ sub ChooseFiles
 	FileChooser_add_filters($dialog,@$patterns);
 	if ($remember_key)
 	{	my $path= $Options{$remember_key};
-		$dialog->set_current_folder_uri($path);
+		if ($path) {
+			$dialog->set_current_folder_uri($path);	
+		}
 	}
 
 	my $response=$dialog->run;

--- a/gmusicbrowser.pl
+++ b/gmusicbrowser.pl
@@ -224,12 +224,13 @@ BEGIN
 }
 
 my $thousandsep;
-BEGIN { $thousandsep= POSIX::localeconv()->{thousands_sep}; }
+BEGIN { $thousandsep= POSIX::localeconv()->{thousands_sep} // ''; }
 sub format_number
 {	my ($d,$f)=@_;
 	use locale;
 	$d= $f ? sprintf($f,$d) : ''.($d+0); # ''.($d+0) to force stringification of the number with the locale
 	return $d unless $d=~s/^(-?\d{4,})//; # $d now contains the fractional part
+	return $d unless $thousandsep;
 	my $i=$1; # integer part
 	$i =~ s/(?<=\d)(?=(?:\d\d\d)+\b)/$thousandsep/g;
 	return $i.$d;


### PR DESCRIPTION
…ion (s///) at gmusicbrowser.pl line 234.

Not all locales have thousand_sep as demonstrated by the following code on my computer:

> perl -MData::Dumper -MPOSIX -e 'print Dumper(POSIX::localeconv())'
$VAR1 = {
          'p_sep_by_space' => 1,
          'int_p_sep_by_space' => 1,
          'n_sep_by_space' => 1,
          'decimal_point' => ',',
          'frac_digits' => 2,
          'p_cs_precedes' => 0,
          'int_frac_digits' => 2,
          'n_cs_precedes' => 0,
          'int_p_cs_precedes' => 0,
          'int_n_sign_posn' => 1,
          'mon_grouping' => '',
          'int_p_sign_posn' => 1,
          'int_curr_symbol' => 'EUR ',
          'int_n_cs_precedes' => 0,
          'mon_thousands_sep' => '.',
          'negative_sign' => '-',
          'currency_symbol' => "\x{20ac}",
          'mon_decimal_point' => ',',
          'int_n_sep_by_space' => 1,
          'p_sign_posn' => 1,
          'n_sign_posn' => 1
        };


And also addresses #207 


First PR! :-D

EDIT: Sorry for two fixes being in the same PR. I pretended to make only one fix that i forgot to change branch.