### PR TITLE
fix hang caused by Gtk3 -init breaking float arithmetic in non-C locales

### DIFF
--- a/gmusicbrowser.pl
+++ b/gmusicbrowser.pl
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use locale qw/ :numeric /;    # fix arithmetic broken by Gtk3 -init setting LC_NUMERIC to user locale (see github #253)
 use strict;
 use warnings;
 use utf8;


### PR DESCRIPTION
Gtk3's gtk_init() calls setlocale(LC_ALL, "") which sets LC_NUMERIC to the user's locale. In locales using comma as decimal separator (e.g. uk_UA.UTF-8), this causes Perl to misinterpret float literals like .8 as 0, making Breakdown_List loop infinitely with $max=0.

use locale :numeric tells Perl to properly manage LC_NUMERIC, keeping C locale for arithmetic while respecting user locale for display.

Resolves #253