### PR TITLE
fix hang with gdk-pixbuf >=2.44 Glycin: don't set SIGCHLD to IGNORE

### DIFF
--- a/generic_metadata_reader_gstreamer.pm
+++ b/generic_metadata_reader_gstreamer.pm
@@ -184,6 +184,7 @@ sub launch_and_parse
 	{	push @output, $_;
 	}
 	close $content_fh;
+	waitpid($pid,0) if $pid; #reap child to avoid zombies (SIGCHLD is not set to IGNORE)
 	::ReadRefFromLines(\@output,$self);
 }
 

--- a/generic_metadata_reader_mediainfo.pm
+++ b/generic_metadata_reader_mediainfo.pm
@@ -103,6 +103,7 @@ sub new
 		}
 	}
 	close $content_fh;
+	waitpid($pid,0) if $pid; #reap child to avoid zombies (SIGCHLD is not set to IGNORE)
 	if ($xml{'General/Duration'}) # ignore file if we don't have a duration
 	{	if (my $menu=$xml{Menu})
 		{	my @toc;

--- a/gmusicbrowser.pl
+++ b/gmusicbrowser.pl
@@ -142,7 +142,8 @@ use Scalar::Util qw/blessed weaken refaddr/;
 use Unicode::Normalize 'NFKD'; #for accent-insensitive sort and search, only used via superlc()
 use Carp;
 $SIG{INT} = sub {&Carp::cluck; exit 2};
-$SIG{CHLD}= 'IGNORE'; # to get rid of zombie child processes
+# don't set SIGCHLD to IGNORE: gdk-pixbuf >=2.44 Glycin needs SIGCHLD to manage its sandbox subprocesses via GLib
+# reaping of our own child processes (forksystem etc) is handled by GLib's child watch or by waitpid in the backends
 
 #use constant SLASH => ($^O  eq 'MSWin32')? '\\' : '/';
 use constant SLASH => '/'; #gtk file chooser use '/' in win32 and perl accepts both '/' and '\'
@@ -1761,7 +1762,7 @@ sub forksystem
 	my @cmd=@_; #can be (cmd,arg1,arg2,...) or ([cmd1,arg1,arg2,...],[cmd2,$arg1,arg2,...])
 	if (ref $cmd[0] && @cmd==1) { @cmd=@{$cmd[0]}; } #simplify if only 1 command
 	my $ChildPID=fork;
-	if (!defined $ChildPID) { warn ::ErrorMessage("forksystem : fork failed : $!"); }
+	if (!defined $ChildPID) { warn ::ErrorMessage("forksystem : fork failed : $!"); return }
 	if ($ChildPID==0) #child
 	{	if (ref $cmd[0])
 		{	system @$_ for @cmd;	#execute multiple commands, one at a time, from the child process
@@ -1769,6 +1770,7 @@ sub forksystem
 		else { exec @cmd; }	#execute one command in the child process
 		POSIX::_exit(0);
 	}
+	Glib::child_watch_add(Glib::G_PRIORITY_LOW,$ChildPID,sub {}) if $ChildPID; #reap child via GLib to avoid zombies
 }
 
 
@@ -2773,7 +2775,7 @@ sub SaveTags	#save tags _and_ settings
 	if ($fork)
 	{	my $pid= fork;
 		if (!defined $pid) { $fork=undef; } # error, fallback to saving in current process
-		elsif ($pid) { return }
+		elsif ($pid) { Glib::child_watch_add(Glib::G_PRIORITY_LOW,$pid,sub {}); return } #reap child via GLib to avoid zombies
 	}
 
 	setlocale(LC_NUMERIC, 'C');

--- a/gmusicbrowser.pl
+++ b/gmusicbrowser.pl
@@ -1770,7 +1770,7 @@ sub forksystem
 		else { exec @cmd; }	#execute one command in the child process
 		POSIX::_exit(0);
 	}
-	Glib::child_watch_add(Glib::G_PRIORITY_LOW,$ChildPID,sub {}) if $ChildPID; #reap child via GLib to avoid zombies
+	Glib::Child->watch_add($ChildPID, sub {}, undef, Glib::G_PRIORITY_LOW) if $ChildPID; #reap child via GLib to avoid zombies
 }
 
 
@@ -2775,7 +2775,7 @@ sub SaveTags	#save tags _and_ settings
 	if ($fork)
 	{	my $pid= fork;
 		if (!defined $pid) { $fork=undef; } # error, fallback to saving in current process
-		elsif ($pid) { Glib::child_watch_add(Glib::G_PRIORITY_LOW,$pid,sub {}); return } #reap child via GLib to avoid zombies
+		elsif ($pid) { Glib::Child->watch_add($pid, sub {}, undef, Glib::G_PRIORITY_LOW); return } #reap child via GLib to avoid zombies
 	}
 
 	setlocale(LC_NUMERIC, 'C');

--- a/gmusicbrowser_123.pm
+++ b/gmusicbrowser_123.pm
@@ -252,7 +252,7 @@ sub Stop
 	}
 }
 sub _Kill_timeout	#make sure old children are dead
-{	@pidToKill=grep kill(0,$_), @pidToKill;
+{	@pidToKill=grep { waitpid($_,WNOHANG)==0 && kill(0,$_) } @pidToKill; #reap finished children and check which are still running
 	if (@pidToKill)
 	{ warn "killing -9 @pidToKill\n" if $::debug;
 	  kill KILL=>@pidToKill;

--- a/gmusicbrowser_mplayer.pm
+++ b/gmusicbrowser_mplayer.pm
@@ -193,7 +193,7 @@ sub Stop
 	}
 }
 sub _Kill_timeout	#make sure old children are dead
-{	@pidToKill=grep kill(0,$_), @pidToKill; #checks to see which ones are still there
+{	@pidToKill=grep { waitpid($_,WNOHANG)==0 && kill(0,$_) } @pidToKill; #reap finished children and check which are still running
 	if (@pidToKill)
 	{	warn "Sending ".($Kill9 ? 'KILL' : 'INT')." signal to @pidToKill\n" if $::debug;
 		if ($Kill9)	{kill KILL=>@pidToKill;}

--- a/gmusicbrowser_mpv.pm
+++ b/gmusicbrowser_mpv.pm
@@ -265,7 +265,7 @@ sub Stop
 	}
 }
 sub _Kill_timeout	#make sure old children are dead
-{	@pidToKill=grep kill(0,$_), @pidToKill; #checks to see which ones are still there
+{	@pidToKill=grep { waitpid($_,WNOHANG)==0 && kill(0,$_) } @pidToKill; #reap finished children and check which are still running
 	if (@pidToKill)
 	{	warn "Sending ".($Kill9 ? 'KILL' : 'INT')." signal to @pidToKill\n" if $::debug;
 		if ($Kill9)	{kill KILL=>@pidToKill;}

--- a/gmusicbrowser_server.pm
+++ b/gmusicbrowser_server.pm
@@ -7,6 +7,7 @@
 package Play_Server;
 use strict;
 use warnings;
+use POSIX ':sys_wait_h';	#for WNOHANG in waitpid
 
 my ($ChildPID,$WatchTag,$fh,@pidToKill);
 my $cmd=$::DATADIR.::SLASH.'iceserver.pl';
@@ -34,6 +35,7 @@ sub Play
 sub _eos_cb
 {	Glib::Source->remove($WatchTag) or warn "couldn't remove watcher";
 	undef $WatchTag;
+	waitpid($ChildPID, WNOHANG) if $ChildPID; #reap child
 	undef $ChildPID;
 	::end_of_file_faketime();
 	return 1;
@@ -54,7 +56,7 @@ sub Stop
 	}
 }
 sub _Kill_timeout	#make sure old children are dead
-{	@pidToKill=grep kill(0,$_), @pidToKill;
+{	@pidToKill=grep { waitpid($_,WNOHANG)==0 && kill(0,$_) } @pidToKill; #reap finished children and check which are still running
 	if (@pidToKill)
 	{ warn "killing -9 @pidToKill\n" if $::debug;
 	  kill KILL => @pidToKill;

--- a/simple_http_wget.pm
+++ b/simple_http_wget.pm
@@ -79,6 +79,7 @@ sub receiving_cb
 {	my $self=$_[2];
 	return 1 if read $self->{content_fh},$self->{content},1024,length($self->{content});
 	close $self->{content_fh};
+	waitpid($self->{pid},0) if $self->{pid}; #reap child to avoid zombies (SIGCHLD is not set to IGNORE)
 	$self->{pid}=$self->{sock}=$self->{watch}=undef;
 	my $url=	$self->{params}{url};
 	my $callback=	$self->{params}{cb};
@@ -147,7 +148,7 @@ sub abort
 {	my $self=$_[0];
 	Glib::Source->remove($self->{watch}) if $self->{watch};
 	Glib::Source->remove($self->{ewatch}) if $self->{ewatch};
-	kill INT=>$self->{pid} if $self->{pid};
+	if ($self->{pid}) { kill INT=>$self->{pid}; waitpid($self->{pid},0); } #reap child to avoid zombies
 	close $self->{content_fh} if defined $self->{content_fh};
 	close $self->{error_fh} if defined $self->{error_fh};
 	$self->{pid}=$self->{content_fh}=$self->{error_fh}=$self->{watch}=$self->{ewatch}=undef;


### PR DESCRIPTION
Disclaimer: I'm not a Perl developper. I did the whole thing using a LLM. It looks sound to me, also passed tests and everything. But probably a seasoned perl developer should take a look at it @squentin  ;-)

gdk-pixbuf 2.44 introduced Glycin, which decodes images in sandboxed child processes (bwrap). Setting $SIG{CHLD}='IGNORE' caused the kernel to auto-reap these children before GLib's GSubprocess could collect their exit status, making every gdk-pixbuf image load hang indefinitely.

Fix by removing $SIG{CHLD}='IGNORE' and instead properly reaping child processes at each fork site:
- forksystem and SaveTags: use Glib::child_watch_add
- metadata readers and simple_http_wget: use waitpid after completion
- mpv/mplayer _Kill_timeout: use waitpid(WNOHANG) to reap zombies

Also fix a pre-existing bug in forksystem where fork failure (undef) fell through into the child branch because undef==0 in numeric context.

Fixes: https://github.com/squentin/gmusicbrowser/issues/262